### PR TITLE
Signaling server 구현

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,8 +23,11 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/platform-socket.io": "^10.4.6",
+    "@nestjs/websockets": "^10.4.6",
     "reflect-metadata": "^0.2.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "socket.io": "^4.8.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -1,22 +1,22 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
+import { Test, TestingModule } from "@nestjs/testing";
+import { AppController } from "./app.controller";
+import { AppService } from "./app.service";
 
-describe('AppController', () => {
-  let appController: AppController;
+describe("AppController", () => {
+    let appController: AppController;
 
-  beforeEach(async () => {
-    const app: TestingModule = await Test.createTestingModule({
-      controllers: [AppController],
-      providers: [AppService],
-    }).compile();
+    beforeEach(async () => {
+        const app: TestingModule = await Test.createTestingModule({
+            controllers: [AppController],
+            providers: [AppService],
+        }).compile();
 
-    appController = app.get<AppController>(AppController);
-  });
-
-  describe('root', () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
+        appController = app.get<AppController>(AppController);
     });
-  });
+
+    describe("root", () => {
+        it('should return "Hello World!"', () => {
+            expect(appController.getHello()).toBe("Hello World!");
+        });
+    });
 });

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,12 +1,12 @@
-import { Controller, Get } from '@nestjs/common';
-import { AppService } from './app.service';
+import { Controller, Get } from "@nestjs/common";
+import { AppService } from "./app.service";
 
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService) {}
+    constructor(private readonly appService: AppService) {}
 
-  @Get()
-  getHello(): string {
-    return this.appService.getHello();
-  }
+    @Get()
+    getHello(): string {
+        return this.appService.getHello();
+    }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,10 +1,11 @@
-import { Module } from '@nestjs/common';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
+import { Module } from "@nestjs/common";
+import { AppController } from "./app.controller";
+import { AppService } from "./app.service";
+import { SocketModule } from "./socket/socket.module";
 
 @Module({
-  imports: [],
-  controllers: [AppController],
-  providers: [AppService],
+    imports: [SocketModule],
+    controllers: [AppController],
+    providers: [AppService],
 })
 export class AppModule {}

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -1,8 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable } from "@nestjs/common";
 
 @Injectable()
 export class AppService {
-  getHello(): string {
-    return 'Hello World!';
-  }
+    getHello(): string {
+        return "Hello World!";
+    }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,8 @@
-import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "./app.module";
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  await app.listen(process.env.PORT ?? 3000);
+    const app = await NestFactory.create(AppModule);
+    await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -1,0 +1,124 @@
+import {
+    WebSocketGateway,
+    WebSocketServer,
+    OnGatewayConnection,
+    OnGatewayDisconnect,
+    SubscribeMessage,
+    MessageBody,
+} from "@nestjs/websockets";
+import { Server } from "socket.io";
+
+interface User {
+    id: string;
+    nickname: string;
+}
+
+@WebSocketGateway({
+    cors: {
+        origin: "*", // CORS 설정
+    },
+})
+export class SocketGateway implements OnGatewayConnection, OnGatewayDisconnect {
+    @WebSocketServer()
+    server: Server;
+
+    private users: { [key: string]: User[] } = {};
+    private socketToRoom: { [key: string]: string } = {};
+    private maximum = 5;
+
+    handleConnection(socket: any) {
+        console.log(`Client connected: ${socket.id}`);
+    }
+
+    handleDisconnect(socket: any) {
+        console.log(`Client disconnected: ${socket.id}`);
+        const roomID = this.socketToRoom[socket.id];
+        if (roomID) {
+            const room = this.users[roomID];
+            if (room) {
+                this.users[roomID] = room.filter(
+                    (user) => user.id !== socket.id
+                );
+                if (this.users[roomID].length === 0) {
+                    delete this.users[roomID];
+                } else {
+                    this.server.to(roomID).emit("user_exit", { id: socket.id });
+                }
+            }
+        }
+    }
+
+    @SubscribeMessage("join_room")
+    handleJoinRoom(socket: any, data: { room: string; nickname: string }) {
+        if (this.users[data.room]) {
+            if (this.users[data.room].length === this.maximum) {
+                socket.emit("room_full");
+                return;
+            }
+            this.users[data.room].push({
+                id: socket.id,
+                nickname: data.nickname,
+            });
+        } else {
+            this.users[data.room] = [
+                { id: socket.id, nickname: data.nickname },
+            ];
+        }
+
+        this.socketToRoom[socket.id] = data.room;
+        socket.join(data.room);
+        console.log(`[${data.room}]: ${socket.id} enter`);
+
+        const usersInThisRoom = this.users[data.room].filter(
+            (user) => user.id !== socket.id
+        );
+        socket.emit("all_users", usersInThisRoom);
+    }
+
+    @SubscribeMessage("offer")
+    handleOffer(
+        @MessageBody()
+        data: {
+            offerReceiveID: string;
+            sdp: any;
+            offerSendID: string;
+            offerSendNickname: string;
+        }
+    ) {
+        this.server.to(data.offerReceiveID).emit("getOffer", {
+            sdp: data.sdp,
+            offerSendID: data.offerSendID,
+            offerSendNickname: data.offerSendNickname,
+        });
+    }
+
+    @SubscribeMessage("answer")
+    handleAnswer(
+        @MessageBody()
+        data: {
+            answerReceiveID: string;
+            sdp: any;
+            answerSendID: string;
+        }
+    ) {
+        this.server.to(data.answerReceiveID).emit("getAnswer", {
+            sdp: data.sdp,
+            answerSendID: data.answerSendID,
+        });
+    }
+
+    @SubscribeMessage("candidate")
+    handleCandidate(
+        @MessageBody()
+        data: {
+            candidateReceiveID: string;
+            candidate: any;
+            candidateSendID: string;
+        }
+    ) {
+        this.server.to(data.candidateReceiveID).emit("getCandidate", {
+            candidate: data.candidate,
+            candidateSendID: data.candidateSendID,
+        });
+    }
+}

--- a/backend/src/socket/socket.module.ts
+++ b/backend/src/socket/socket.module.ts
@@ -1,0 +1,7 @@
+import { Module } from "@nestjs/common";
+import { SocketGateway } from "./socket.gateway";
+
+@Module({
+    providers: [SocketGateway],
+})
+export class SocketModule {}


### PR DESCRIPTION
# 백엔드 signaling server 구현

## 관련 이슈 번호
> - 작성자: J141_송수민
> - 작성 날짜: 2024.11.05

- #11 

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- WebSocket과 socket.io를 이용한 signaling server 구현 
    - join_room 이벤트
    - offer 이벤트
    - answer 이벤트
    - candidate 이벤트

## 📝 작업 상세 내역
### 웹소켓 연결 설정 및 해제 기능
- 웹소켓이 연결되면 로그를 찍고, 연결이 해제되면 해당 방에 있던 나머지 사용자에게 퇴장 이벤트를 보낸다.
```ts
class SocketGateway implements OnGatewayConnection, OnGatewayDisconnect {
    @WebSocketServer()
    server: Server;

    private users: { [key: string]: User[] } = {}; // { '방 이름': [ { id: '소켓id', nickname: '유저 닉네임' }, ... ], ... }
    private socketToRoom: { [key: string]: string } = {}; // { '소켓id': '방 이름', ... }
    private maximum = 5; // 방 하나에 최대 5명 입장 가능

    handleConnection(socket: any) {
        console.log(`Client connected: ${socket.id}`);
    }

    handleDisconnect(socket: any) {
        console.log(`Client disconnected: ${socket.id}`);
        const roomID = this.socketToRoom[socket.id];
        if (roomID) {
            const room = this.users[roomID];
            if (room) {
                this.users[roomID] = room.filter(
                    (user) => user.id !== socket.id
                );
                if (this.users[roomID].length === 0) {
                    delete this.users[roomID];
                } else {
                    this.server.to(roomID).emit("user_exit", { id: socket.id });
                }
            }
        }
    }
}
```

### signaling server 구현
1. 방 참여 처리 (handleJoinRoom):
    * 사용자가 방에 들어올 때, 현재 방의 인원 수를 확인하여 최대 인원을 초과하면 "room_full" 이벤트를 통해 클라이언트에 알린다.
    * 방에 새로운 사용자를 추가하고, 현재 방에 있는 사용자 목록을 클라이언트에 전송한다.
2. offer 처리 (handleOffer):
    * 사용자가 다른 사용자에게 WebRTC 연결 요청을 위한 오퍼를 전송한다.
    * 수신자에게 오퍼와 함께 송신자의 ID와 닉네임을 포함하여 전송한다.
3. answer 처리 (handleAnswer):
    * 상대방이 오퍼에 대한 응답을 보내면, 이를 수신자에게 전달한다.
    * 응답과 함께 송신자의 ID를 포함하여 전송한다.
4. candidate 처리 (handleCandidate):
    * ICE 후보가 생성되면 이를 해당 후보를 수신해야 하는 사용자에게 전달한다.
    * 수신자에게 후보 정보와 송신자의 ID를 함께 전송한다.

## 📌 테스트 및 검증 결과
### 웹소켓 연결 설정 및 해제 기능
<img width="713" alt="image" src="https://github.com/user-attachments/assets/d424ce4e-2428-4452-8a10-d3a8ebd25572">

### signaling server 구현
1. 방 참여, 퇴장 처리
    1. join_room
    ![image](https://github.com/user-attachments/assets/63cb4ebc-8820-4a3a-927b-0ccd92b1d9ea)
    * 방에 입장하면 해당 방의 기존 사람들의 socket id와 nickname도 확인할 수 있다.

    2. room_full
    ![image](https://github.com/user-attachments/assets/1cb4aadd-557a-41d3-b554-5645a6509707)
    * 방에 6번째로 접근한 사람에게는 room_full 이벤트가 전송된다.

    3. user_exit
    ![image](https://github.com/user-attachments/assets/be77eecd-691b-4604-b438-487c51d6f9b6)
    * 특정 사용자의 연결이 해제되면 해당 방의 나머지 사용자들에게 user_exit 이벤트가 전송된다.

2. offer 처리
* nickname1이 nickname2에게 offer를 전송한다.
![image](https://github.com/user-attachments/assets/f0a8ebf3-a7ba-4f3b-a57e-787e768f82aa)
* nickname2가 nickname1의 offer를 getOffer 이벤트로 전송받았다.
![image](https://github.com/user-attachments/assets/8288febb-c7aa-459b-aff0-1fe04a639d0f)
* sdp 데이터는 예시로서 작성했다.

3. answer 처리
* nickname1이 nickname2에게 answer를 전송한다.
![image](https://github.com/user-attachments/assets/d7cc5e97-8450-4e69-b0e9-698435ceb4bd)
* nickname2가 nickname1의 answer를 getAnswer로 전송받았다.
![image](https://github.com/user-attachments/assets/b0f66416-0e35-4065-91b8-74da0537b762)

4. candidate 처리
* nickname1이 nickname2에게 candidate을 전송한다.
![image](https://github.com/user-attachments/assets/22629bb7-7c61-4daa-81ac-e3d167c80ce8)
* nickname2가 nickname1의 candidate을 전송 받았다.
![image](https://github.com/user-attachments/assets/0acd5a03-2a76-4a99-8983-8d8e77c022ba)

## 💬 다음 작업 또는 논의 사항
- postman도 좋지만 다른 웹소켓 코드 테스트 방법도 알아보고 싶다.

## 📎 참고 자료
- [승윤님의 websocket 코드 예제](https://github.com/boostcampwm-2024/web27-Preview/pull/51)
- [[서버] postman을 이용하여 websocket 테스트하기](https://blog.naver.com/pjt3591oo/222525963872)