### PR TITLE
[Fix] 화상회의 오디오 버그, 세션 가득찬 상황 대처에 대한 버그 수정

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,7 @@ function App() {
 
   useEffect(() => {
     navigate("/sessions");
-  }, []);
+  }, [navigate]);
 
   return (
     <section className={"flex flex-col gap-3"}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,94 +1,17 @@
-import { useRef, useState } from "react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 function App() {
-  const [startButtonActive] = useState(true);
-  const [status, setStatus] = useState("연결 대기중");
+  const navigate = useNavigate();
+  const [status] = useState("연결 대기중");
 
-  const localVideoRef = useRef<HTMLVideoElement | null>(null);
-  const remoteVideoRef = useRef<HTMLVideoElement | null>(null);
-  // WebRTC 설정
-
-  // 변수 선언
-
-  const [localStream, setLocalStream] = useState<MediaStream | null>(null);
-  // const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null);
-  // const [peerConnection, setPeerConnection] =
-  //   useState<RTCPeerConnection | null>(null);
-
-  // 미디어 스트림 시작
-  async function startCall() {
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({
-        video: true,
-      });
-
-      if (localVideoRef.current) {
-        localVideoRef.current!.srcObject = stream;
-        setLocalStream(stream);
-      }
-
-      setStatus("비디오 켜는 중...");
-    } catch (e) {
-      console.error("미디어 스트림 획득 실패:", e);
-      setStatus("카메라/마이크 접근 실패");
-    }
-  }
-
-  async function stopVideo() {
-    try {
-      if (localStream) {
-        localStream.getTracks().forEach((track) => {
-          track.stop();
-        });
-        setLocalStream(null);
-      }
-    } catch (e) {
-      console.error("비디오 중지 실패:", e);
-    }
-  }
+  useEffect(() => {
+    navigate("/sessions");
+  }, []);
 
   return (
     <section className={"flex flex-col gap-3"}>
-      <div className="flex gap-3 justify-center">
-        <video
-          className={"w-80 aspect-video object-cover rounded-md bg-black"}
-          ref={localVideoRef}
-          id="localVideo"
-          autoPlay
-          playsInline
-          muted
-        ></video>
-        <video
-          className={"w-80 aspect-video rounded-md bg-black"}
-          ref={remoteVideoRef}
-          id="remoteVideo"
-          autoPlay
-          playsInline
-        ></video>
-      </div>
-      <div className="flex gap-3 justify-center">
-        <video
-          className={"w-80 aspect-video object-cover rounded-md bg-black"}
-          id="localVideo"
-          autoPlay
-          playsInline
-          muted
-        ></video>
-        <video
-          className={"w-80 aspect-video rounded-md bg-black"}
-          id="remoteVideo"
-          autoPlay
-          playsInline
-        ></video>
-      </div>
-      <div>
-        <button
-          onClick={!localStream ? startCall : stopVideo}
-          disabled={!startButtonActive}
-        >
-          {!localStream ? "비디오 켜기" : "비디오 끄기"}
-        </button>
-      </div>
+      <p>이걸 보다니 실력자시군요?</p>
       <div id="connectionStatus">{status}</div>
     </section>
   );

--- a/frontend/src/components/SessionCard.tsx
+++ b/frontend/src/components/SessionCard.tsx
@@ -8,6 +8,7 @@ interface Props {
   maxParticipant: number;
   sessionStatus: "open" | "close";
   questionListId: number;
+  onEnter: () => void;
 }
 
 const SessionCard = ({
@@ -18,6 +19,7 @@ const SessionCard = ({
   maxParticipant,
   sessionStatus,
   questionListId,
+  onEnter,
 }: Props) => {
   return (
     <li
@@ -52,8 +54,9 @@ const SessionCard = ({
           </div>
           <button
             className={
-              "text-semibold-s text-primary-dark hover:text-primary-dark-hover bg-transparent inline-flex items-center"
+              "text-semibold-s text-primary-dark hover:text-primary-dark-hover bg-transparent inline-flex items-center gap-1 hover:gap-0.5 transition-all"
             }
+            onClick={onEnter}
           >
             <span>참여하기</span> <FaArrowRight />
           </button>

--- a/frontend/src/components/VideoContainer.tsx
+++ b/frontend/src/components/VideoContainer.tsx
@@ -10,19 +10,26 @@ interface VideoContainerProps {
   nickname: string;
   isMicOn: boolean;
   isVideoOn: boolean;
+  isLocal: boolean;
 }
 
 const VideoContainer = forwardRef(
   (
-    { nickname, isMicOn, isVideoOn }: VideoContainerProps,
+    { nickname, isMicOn, isVideoOn, isLocal }: VideoContainerProps,
     ref: React.Ref<HTMLVideoElement>
   ) => {
     return (
       <div className="bg-black rounded-2xl overflow-hidden shadow relative">
-        <video ref={ref} autoPlay playsInline muted className="w-full" />
+        <video
+          ref={ref}
+          autoPlay
+          playsInline
+          muted={isLocal}
+          className="w-full"
+        />
         <div className="inline-flex gap-4 absolute bottom-2 w-full justify-between px-2">
           <p className="bg-accent-gray  bg-opacity-50 text-white px-2 py-0.5 rounded">
-            {nickname}
+            {isLocal && "Me"} {nickname}
           </p>
           <div className={"inline-flex gap-4 px-2 items-center"}>
             {isMicOn ? (

--- a/frontend/src/components/VideoRoom.tsx
+++ b/frontend/src/components/VideoRoom.tsx
@@ -7,6 +7,7 @@ import {
   BsCameraVideo,
   BsCameraVideoOff,
 } from "react-icons/bs";
+import { useNavigate } from "react-router-dom";
 
 interface User {
   id: string;
@@ -32,6 +33,7 @@ const VideoRoom = () => {
   const peerConnections = useRef<{ [key: string]: RTCPeerConnection }>({});
   const peerVideoRefs = useRef<{ [key: string]: HTMLVideoElement | null }>({});
 
+  const navigate = useNavigate();
   // STUN 서버 설정
   const pcConfig = {
     iceServers: [
@@ -145,6 +147,14 @@ const VideoRoom = () => {
 
     socket.emit("join_room", { room: roomId, nickname });
 
+    socket.on("room_full", () => {
+      console.log("방이 꽉찼심");
+      alert(
+        "해당 세션은 이미 유저가 가득 찼습니다. 세션 페이지로 이동합니다..."
+      );
+      navigate("/sessions");
+      return;
+    });
     // 기존 사용자들의 정보 수신: 방에 있던 사용자들과 createPeerConnection 생성
     socket.on("all_users", (users: User[]) => {
       users.forEach((user) => {

--- a/frontend/src/components/VideoRoom.tsx
+++ b/frontend/src/components/VideoRoom.tsx
@@ -143,7 +143,13 @@ const VideoRoom = () => {
     if (!socket || !roomId || !nickname) return;
 
     const stream = await getMedia();
-    if (!stream) return;
+    if (!stream) {
+      alert(
+        "미디어 스트림을 가져오지 못했습니다. 미디어 장치를 확인 후 다시 시도해주세요."
+      );
+      navigate("/sessions");
+      return;
+    }
 
     socket.emit("join_room", { room: roomId, nickname });
 

--- a/frontend/src/components/VideoRoom.tsx
+++ b/frontend/src/components/VideoRoom.tsx
@@ -45,7 +45,9 @@ const VideoRoom = () => {
 
   useEffect(() => {
     // 소켓 연결
-    const newSocket = io(import.meta.env.SIGNALING_SERVER_URL);
+    const newSocket = io(
+      import.meta.env.SIGNALING_SERVER_URL || "http://localhost:3000"
+    );
     setSocket(newSocket);
 
     // ref 값을 useEffect 안에서 캡처
@@ -370,6 +372,7 @@ const VideoRoom = () => {
           nickname={nickname}
           isMicOn={isMicOn}
           isVideoOn={isVideoOn}
+          isLocal={true}
         />
 
         {
@@ -386,6 +389,7 @@ const VideoRoom = () => {
               nickname={peer.peerNickname}
               isMicOn={true}
               isVideoOn={true}
+              isLocal={false}
             />
           ))
         }

--- a/frontend/src/pages/SessionListPage.tsx
+++ b/frontend/src/pages/SessionListPage.tsx
@@ -1,6 +1,7 @@
 import { FaCirclePlus } from "react-icons/fa6";
 import { useEffect, useState } from "react";
 import SessionCard from "../components/SessionCard.tsx";
+import { useNavigate } from "react-router-dom";
 
 interface Session {
   id: number;
@@ -21,6 +22,7 @@ enum SessionStatus {
 const SessionListPage = () => {
   const [sessionList, setSessionList] = useState<Session[]>([]);
   const [listLoading, setListLoading] = useState(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const sessionData: Session[] = [
@@ -66,6 +68,7 @@ const SessionListPage = () => {
             questionListId={1}
             participant={session.participant}
             maxParticipant={session.maxParticipant}
+            onEnter={() => navigate(`/session/${session.id}`)}
           />
         )
       );


### PR DESCRIPTION
## 관련 이슈 번호
- #11 

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- 오디오 송출 버그 수정
- 세션 가득찼을 때의 예외처리 구현
- index로 접근시 sessions 페이지로 리다이렉션

## 📝 작업 상세 내역
### 오디오 버그 수정
- 해당 버그는 컴포넌트 재사용 과정에서 muted 속성이 재사용되었기 때문에 발생한 오류이다.
- 컴포넌트에 isLocal 상태를 추가하여 본인의 스트림의 경우에만 muted를 적용하고, 다른 사람들의 스트림에는 muted를 적용하지 않는 방식으로 해결했다.

### room_full 이벤트 대응
- 문제 상황 : 세션이 가득찼을 경우 마지막에 들어온 유저는 미디어 장치만 켜지고 세션에 입장이 되지 않던 오류
- 시그널링 서버에서 세션에 사람이 가득찬 경우에 발생시키는 `room_full` 이벤트에 대해 핸들러를 추가하는 방식으로 해결

## 📌 테스트 및 검증 결과
- 세션에 이미 5명이 들어와있고, 그 후에 1명이 더 들어오는 경우
<img width="516" alt="image" src="https://github.com/user-attachments/assets/fbcc171f-9693-4e01-a86f-2d8ee660ce32">


## 💬 다음 작업 또는 논의 사항
- 오류 메시지를 alert가 아닌 toast 메시지로 구현하면 더 UI/UX가 좋아질 것 같다.

## 📎 참고 자료 (선택)
- [webRTC 미디어 관련 예제](https://webrtc.github.io/samples/src/content/getusermedia/audio/)
