### PR TITLE
[Design] 세션 리스트 페이지 디자인

### DIFF
--- a/frontend/src/components/SessionCard.tsx
+++ b/frontend/src/components/SessionCard.tsx
@@ -1,5 +1,5 @@
 import { FaUserGroup } from "react-icons/fa6";
-import { FaArrowRight } from "react-icons/fa";
+import { IoArrowForwardSharp } from "react-icons/io5";
 interface Props {
   category: string;
   title: string;
@@ -23,43 +23,44 @@ const SessionCard = ({
 }: Props) => {
   return (
     <li
-      className={
-        "relative flex rounded-2xl overflow-hidden border border-accent-gray py-3 max-w-3xl"
-      }
+      className={`relative flex rounded-custom-l border-l-[1.625rem] ${sessionStatus === "open" ? "border-l-point-2" : "border-l-green-200"} bg-gray-white shadow-8 overflow-hidden py-3 max-w-[47.5rem] h-[8.75rem]`}
     >
-      <div
-        className={`${sessionStatus === "open" ? "bg-accent-gray" : "bg-primary-active"} w-6 h-full absolute left-0 top-0`}
-        aria-label={"상태표시등"}
-      />
-      <div className={"flex-grow px-4 ml-6 flex flex-col gap-1 items-start"}>
+      <div className={"flex-grow px-[0.75rem] flex flex-col items-start"}>
         <span
           className={
-            "text-medium-xs border border-primary-dark rounded-2xl py-px px-2"
+            "text-medium-xs border-[0.0875rem] border-green-600 rounded-2xl py-px px-2"
           }
         >
           {category}
         </span>
-        <h3 className={"text-semibold-r text-xl"}>{title}</h3>
-        <p className={"text-medium-r text-grayscale-400"}>
+        <h3 className={"text-semibold-r mt-[0.5rem]"}>{title}</h3>
+        <p className={"text-medium-r text-gray-400"}>
           질문지인데 누르면 질문 리스트를 볼 수 있임 {questionListId}
         </p>
-        <div className={"inline-flex items-center justify-between w-full"}>
+        <div
+          className={
+            "absolute bottom-[0.75rem] left-0 px-[0.75rem] inline-flex items-center justify-between w-full"
+          }
+        >
           <div className={"text-medium-s inline-flex items-center gap-1"}>
             <span>{host} • </span>
             <span className={"inline-flex items-center gap-1"}>
-              <FaUserGroup />{" "}
+              <FaUserGroup className="text-green-400" />{" "}
               <span className={"inline-flex items-center"}>참여자</span>
               {participant}/{maxParticipant}명
             </span>
           </div>
-          <button
-            className={
-              "text-semibold-s text-primary-dark hover:text-primary-dark-hover bg-transparent inline-flex items-center gap-1 hover:gap-0.5 transition-all"
-            }
-            onClick={onEnter}
-          >
-            <span>참여하기</span> <FaArrowRight />
-          </button>
+          {sessionStatus === "open" ? (
+            <button
+              className={
+                "text-semibold-s text-green-500 inline-flex items-center gap-[0.5rem] hover:gap-[0.375rem] transition-all"
+              }
+              onClick={onEnter}
+            >
+              <span>참여하기</span>{" "}
+              <IoArrowForwardSharp className="w-[1.25rem] h-[1.25rem] text-green-500" />
+            </button>
+          ) : null}
         </div>
       </div>
     </li>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,9 +1,16 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@import url('https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;600;700&display=swap');
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+
+@layer base {
+  html {
+    font-family: Pretendard, system-ui, sans-serif;
+  }
+}
 
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,12 +1,12 @@
+@import url('https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;600;700&display=swap');
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-@import url('https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;600;700&display=swap');
-@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
 
 @layer base {
   html {
-    font-family: Pretendard, system-ui, sans-serif;
+    font-family: Pretendard, system-ui, sans-serif; 
   }
 }
 
@@ -15,8 +15,7 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  background-color: #FAFAFA;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -24,26 +23,9 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-
-
 @media (prefers-color-scheme: light) {
   :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
+    color: #171717;
+    background-color: #FAFAFA;
   }
 }

--- a/frontend/src/pages/SessionListPage.tsx
+++ b/frontend/src/pages/SessionListPage.tsx
@@ -1,7 +1,9 @@
-import { FaCirclePlus } from "react-icons/fa6";
+import { IoChevronDownSharp } from "react-icons/io5";
 import { useEffect, useState } from "react";
 import SessionCard from "../components/SessionCard.tsx";
 import { useNavigate } from "react-router-dom";
+import { IoMdAdd } from "react-icons/io";
+import { IoIosSearch } from "react-icons/io";
 
 interface Session {
   id: number;
@@ -32,7 +34,7 @@ const SessionListPage = () => {
         category: "프론트엔드",
         sessionStatus: "open",
         host: {
-          nickname: "J133",
+          nickname: "J133 네모정",
         },
         participant: 1,
         maxParticipant: 4,
@@ -55,6 +57,7 @@ const SessionListPage = () => {
       setListLoading(false);
     }, 100);
   }, []);
+
   const renderSessionList = (sessionStatus: SessionStatus) => {
     return sessionList.map((session) => {
       return (
@@ -77,32 +80,39 @@ const SessionListPage = () => {
 
   return (
     <section
-      className={"flex flex-col gap-10 max-w-7xl w-screen h-screen p-20"}
+      className={"flex flex-col gap-8 max-w-7xl w-screen h-screen p-20"}
     >
       <div>
         <h1 className={"text-bold-l mb-6"}>스터디 세션 목록</h1>
-        <div className={"h-10 flex gap-2"}>
-          <input
-            className={"rounded-lg px-4 border h-full"}
-            type="text"
-            placeholder="세션을 검색하세요"
-          />
-          <select className={"rounded-lg px-4 border h-full"}>
-            <option>FE</option>
-            <option>BE</option>
-          </select>
+        <div className={"h-11 flex gap-2 w-[47.5rem]"}>
+          <div className="relative w-full h-full flex items-center text-gray-400">
+            <IoIosSearch className="absolute left-4 w-[1.25rem] h-[1.25rem]" />
+            <input
+              className={"rounded-custom-m pl-10 pr-4 w-full h-full border border-gray-200 text-medium-r"}
+              type="text"
+              placeholder="세션을 검색하세요"
+            />
+          </div>
+          <div className="relative inline-block items-center">
+            <select className={"rounded-custom-m bg-green-200 text-semibold-s text-gray-white appearance-none pl-5 pr-11 h-full"}>
+              <option>FE</option>
+              <option>BE</option>
+            </select>
+            <span className="absolute top-1/2 -translate-y-1/2 right-3 pointer-events-none">
+              <IoChevronDownSharp className="w-[1.25rem] h-[1.25rem] text-gray-white" />
+            </span>
+          </div>
           <button
             className={
-              "flex justify-center items-center fill-current text-white bg-primary hover:bg-primary-hover w-10 h-full rounded-lg"
+              "flex justify-center items-center fill-current min-w-11 min-h-11 bg-green-200 rounded-custom-m box-border"
             }
           >
-            <FaCirclePlus />
+            <IoMdAdd className="w-[1.35rem] h-[1.35rem] text-gray-white" />
           </button>
-          <button>링크입력</button>
         </div>
       </div>
       <div>
-        <h2 className={"text-semibold-xl mb-6"}>공개된 세션 목록</h2>
+        <h2 className={"text-semibold-l mb-6"}>공개된 세션 목록</h2>
         <ul>
           {listLoading ? (
             <>loading</>
@@ -118,7 +128,7 @@ const SessionListPage = () => {
         </ul>
       </div>
       <div>
-        <h2 className={"text-semibold-xl mb-6"}>진행 중인 세션 목록</h2>
+        <h2 className={"text-semibold-l mb-6"}>진행 중인 세션 목록</h2>
         <ul>
           {listLoading ? (
             <>loading</>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -7,53 +7,41 @@ export default {
   theme: {
     extend: {
       colors: {
-        grayscale: {
-          'white-alt': 'rgba(255, 255, 255, 0.7)',
+        gray: {
           white: '#FFFFFF',
-          50: '#F5F7F9',
-          100: '#D2DAE0',
-          200: '#879298',
-          300: '#6E8091',
-          400: '#5F6E76',
-          500: '#4B5966',
-          black: '#14212B',
+          50: '#FAFAFA',
+          100: '#EDEDED',
+          200: '#E1E1E1',
+          300: '#D9D9D9',
+          400: '#6C6C6C',
+          500: '#5E5E5E',
+          600: '#3F3F3F',
+          black: '#171717',
         },
-        primary: {
-          light: {
-            DEFAULT: '#e6f9f1',    // rgb(230, 249, 241)
-            hover: '#d9f5e9',      // rgb(217, 245, 233)
-            active: '#b0ebd2',     // rgb(176, 235, 210)
-          },
-          DEFAULT: '#01bf6f',      // rgb(1, 191, 111)
-          hover: '#01ac64',        // rgb(1, 172, 100)
-          active: '#019959',       // rgb(1, 153, 89)
-          dark: {
-            DEFAULT: '#018f53',    // rgb(1, 143, 83)
-            hover: '#017343',      // rgb(1, 115, 67)
-            active: '#005632',     // rgb(0, 86, 50)
-          },
-          darker: '#004327',       // rgb(0, 67, 39)
+        green: {
+          50: '#F1FBF7',
+          100: '#01BF6F',
+          200: '#01AC64',
+          300: '#019959',
+          400: '#018F53',
+          500: '#017343',
+          600: '#005632',
+          700: '#004327'  
         },
-        accent: {
-          gray: {
-            DEFAULT: '#dfddd5'
-          }
+        point: {
+          1: '#F04040',
+          2: '#DFDDD5',
+          3: '#2572E6'
         }
-      },
-      borderColor: {
-        skin: {
-          bold: 'var(--color-border-bold)',
-          default: 'var(--color-border-default)',
-        },
       },
       fontSize: {
         // Bold(700) sizes
-        'bold-l': ['32px', { lineHeight: 'auto', fontWeight: '700' }],
-        'bold-m': ['28px', { lineHeight: 'auto', fontWeight: '700' }],
+        'bold-l': ['30px', { lineHeight: 'auto', fontWeight: '700' }],
+        'bold-m': ['26px', { lineHeight: 'auto', fontWeight: '700' }],
         'bold-r': ['20px', { lineHeight: 'auto', fontWeight: '700' }],
 
         // SemiBold(600) sizes
-        'semibold-xl': ['28px', { lineHeight: 'auto', fontWeight: '600' }],
+        'semibold-xl': ['26px', { lineHeight: 'auto', fontWeight: '600' }],
         'semibold-l': ['24px', { lineHeight: 'auto', fontWeight: '600' }],
         'semibold-m': ['22px', { lineHeight: 'auto', fontWeight: '600' }],
         'semibold-r': ['20px', { lineHeight: 'auto', fontWeight: '600' }],
@@ -76,4 +64,3 @@ export default {
   },
   plugins: [],
 }
-

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -35,9 +35,9 @@ export default {
         }
       },
       borderRadius: {
-        's': '0.25rem',
-        'm': '0.5rem',
-        'xl': '1rem'
+        'custom-s': '0.25rem',
+        'custom-m': '0.5rem',
+        'custom-l': '0.875rem'
       },
       boxShadow: {
         '8': '0 0 0.2rem 0.125rem rgba(182, 182, 182, 0.08)'

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -34,27 +34,34 @@ export default {
           3: '#2572E6'
         }
       },
+      borderRadius: {
+        's': '0.25rem',
+        'm': '0.5rem',
+        'xl': '1rem'
+      },
+      boxShadow: {
+        '8': '0 0 0.2rem 0.125rem rgba(182, 182, 182, 0.08)'
+      },
       fontSize: {
         // Bold(700) sizes
-        'bold-l': ['30px', { lineHeight: 'auto', fontWeight: '700' }],
-        'bold-m': ['26px', { lineHeight: 'auto', fontWeight: '700' }],
-        'bold-r': ['20px', { lineHeight: 'auto', fontWeight: '700' }],
+        'bold-l': ['1.625rem', { lineHeight: 'auto', fontWeight: '700' }],
+        'bold-m': ['1.5rem', { lineHeight: 'auto', fontWeight: '700' }],
+        'bold-r': ['1.25rem', { lineHeight: 'auto', fontWeight: '700' }],
 
         // SemiBold(600) sizes
-        'semibold-xl': ['26px', { lineHeight: 'auto', fontWeight: '600' }],
-        'semibold-l': ['24px', { lineHeight: 'auto', fontWeight: '600' }],
-        'semibold-m': ['22px', { lineHeight: 'auto', fontWeight: '600' }],
-        'semibold-r': ['20px', { lineHeight: 'auto', fontWeight: '600' }],
-        'semibold-s': ['18px', { lineHeight: 'auto', fontWeight: '600' }],
+        'semibold-l': ['1.375rem', { lineHeight: 'auto', fontWeight: '600' }],
+        'semibold-m': ['1.25rem', { lineHeight: 'auto', fontWeight: '600' }],
+        'semibold-r': ['1.125rem', { lineHeight: 'auto', fontWeight: '600' }],
+        'semibold-s': ['1rem', { lineHeight: 'auto', fontWeight: '600' }],
 
         // Medium(500) sizes
-        'medium-xl': ['24px', { lineHeight: 'auto', fontWeight: '500' }],
-        'medium-l': ['22px', { lineHeight: 'auto', fontWeight: '500' }],
-        'medium-m': ['20px', { lineHeight: 'auto', fontWeight: '500' }],
-        'medium-r': ['18px', { lineHeight: 'auto', fontWeight: '500' }],
-        'medium-s': ['16px', { lineHeight: 'auto', fontWeight: '500' }],
-        'medium-xs': ['14px', { lineHeight: 'auto', fontWeight: '500' }],
-        'medium-xxs': ['12px', { lineHeight: 'auto', fontWeight: '500' }],
+        'medium-xl': ['1.375rem', { lineHeight: 'auto', fontWeight: '500' }],
+        'medium-l': ['1.25rem', { lineHeight: 'auto', fontWeight: '500' }],
+        'medium-m': ['1.125rem', { lineHeight: 'auto', fontWeight: '500' }],
+        'medium-r': ['1rem', { lineHeight: 'auto', fontWeight: '500' }],
+        'medium-s': ['0.875rem', { lineHeight: 'auto', fontWeight: '500' }],
+        'medium-xs': ['0.75rem', { lineHeight: 'auto', fontWeight: '500' }],
+        'medium-xxs': ['0.625rem', { lineHeight: 'auto', fontWeight: '500' }],
       },
       fontFamily: {
         pretendard: ['Pretendard', 'sans-serif'],


### PR DESCRIPTION
> [!NOTE]
> - 작성자: 이승윤
> - 작성 날짜: 2024.11.10
>
> 기존 작업에 디자인만 변경해서 코드 구조라거나 다른 부분은 변경된 사항이 없습니다.

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- 세션 카드 컴포넌트 디자인
- 세션 리스트 페이지 디자인

## 📝 작업 상세 내역
### 세션 리스트 페이지

<img width="100%" alt="스크린샷 2024-11-10 오전 4 21 14" src="https://github.com/user-attachments/assets/4bfeab46-d38a-4bd8-8f34-7faaddc8be1c">

- 원래 세션 카드를 860px로 만들었는데, 피그마 상에서는 괜찮아보였는데 막상 적용하니 너무 카드가 길어 100px 정도 줄였습니다.
  - 나중에 왼쪽에 메뉴바가 올 예정이라 조금 줄이는게 나을거 같다 판단했습니다.
- 피그마 상에서는 잘 몰랐는데 막상 적용해보니 폰트가 너무 크다고 느껴졌습니다.
  - 그래서 적당히 줄였습니다. 그래도 지금도 적당히 큰 편입니다.
- 그 외) 카드 그림자, 폰트 적용

### tailwind.config.js
![스크린샷 2024-11-10 오후 1 46 04](https://github.com/user-attachments/assets/df7a6d01-b04a-4a35-9364-3c788fd1a8df)


- px 단위로 적용했던 것을 `rem` 단위로 정의해두었습니다. 
- 누락되어있던 색상 시스템도 추가해서 적용했습니다.

## 💬 다음 작업 또는 논의 사항
### 페이지의 최소 width
개인적인 생각으로는 면접 연습을 하다보니, 폰보다는 태블릿이나 노트북, 데스크탑으로 이용하는 걸 위주로 고려해야한다 생각을 했습니다. 질문도 봐야하고 다른 사람의 영상도 표시해야하고 그러다보니 폰으로 접속하는 사용자를 고려하지 않아도 되지 않을까 생각했습니다. 줌을 보통 폰으로 이용해서 강의를 들을 때도 답답한데(보통 급한 일 있을 때 줌을 폰으로 이용했었음), 저희는 면접 질문도 띄우고 다른 사람 영상도 다 표시하며 소통하는게 중요하기 때문에 태블릿의 가로 사이즈 정도를 최소 width로 잡고 작업하면 어떨까하는 생각이 들었습니다.
