### PR TITLE
[Feat] 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy to Ncloud Server
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3.3.0 # workflow 내에서 repo의 최신 코드를 checkout
+      - name: Deploy to Ncloud via SSH
+        uses: appleboy/ssh-action@master # GitHub Actions에서 SSH로 서버에 접근
+        with:
+          host: ${{ secrets.REMOTE_SSH_HOST }}
+          username: ${{ secrets.REMOTE_SSH_USERNAME }}
+          key: ${{ secrets.REMOTE_SSH_KEY }}
+          passphrase: ${{ secrets.REMOTE_SSH_PASSPHRASE }}
+          password: ${{ secrets.REMOTE_SSH_PASSWORD }}
+          port: ${{ secrets.REMOTE_SSH_PORT }}
+          script: |
+            echo ${{ secrets.REMOTE_SSH_PASSWORD }} | sudo -S echo deploy start!
+            ./deploy.sh # 배포 스크립트 실행


### PR DESCRIPTION
<!-- 
  Title: 작업 내용 한 줄 요약
  - 사용하지 않는 부분의 항목은 지우고 사용해주세요.
-->

## 관련 이슈 번호
> - 작성자: 김찬우
> - 작성 날짜: 2024.11.09

- 연관된 이슈 번호 없음 (프로젝트 배포)

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용

- `Github Actions` 워크 플로우를 추가했습니다.
  - 해당 워크 플로우는 `main` 브랜치가 업데이트 될 때 실행됩니다.
  - 클라우드에 `ssh` 로 접속하여 배포 스크립트를 실행합니다.

## 📝 작업 상세 내역

### 배포 스크립트 추가
- 클라우드 서버에 매번 접속하여 배포할 필요가 없도록 했습니다.
- `ssh action` 을 사용하였습니다.
- `sudo` 과정 중 비밀번호 입력을 방지하기 위해 `sudo -S` 옵션을 이용하여 사전에 `sudo` 사용권한을 얻고 시작합니다.

```yml
name: Deploy to Ncloud Server
on:
  push:
    branches:
      - main
jobs:
  deploy:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout code
        uses: actions/checkout@v3.3.0 # workflow 내에서 repo의 최신 코드를 checkout
      - name: Deploy to Ncloud via SSH
        uses: appleboy/ssh-action@master # GitHub Actions에서 SSH로 서버에 접근
        with:
          host: ${{ secrets.REMOTE_SSH_HOST }}
          username: ${{ secrets.REMOTE_SSH_USERNAME }}
          key: ${{ secrets.REMOTE_SSH_KEY }}
          passphrase: ${{ secrets.REMOTE_SSH_PASSPHRASE }}
          password: ${{ secrets.REMOTE_SSH_PASSWORD }}
          port: ${{ secrets.REMOTE_SSH_PORT }}
          script: |
            echo ${{ secrets.REMOTE_SSH_PASSWORD }} | sudo -S echo deploy start!
            ./deploy.sh # 배포 스크립트 실행
```

## 📌 테스트 및 검증 결과

- 테스트 브랜치를 따로 본 프로젝트에서 파서 실험을 했습니다.
- 테스트 후 테스트에 사용된 브랜치는 삭제하였습니다.

<img width="547" alt="image" src="https://github.com/user-attachments/assets/72ea6479-0fae-486b-8578-b460d635673f">

## 💬 다음 작업 또는 논의 사항
- 배포 관련해서는 특별한 이슈가 없다면 이렇게 하고 앞으로 백엔드 개발에 집중할  것 같습니다.
- 배포 스크립트는 큰 이슈가 없는 한 크게 리뷰할 것들이 없을 것 같네요.