### PR TITLE
[Refactor] 세션 페이지 P2P 연결 수립 부분 분리, 미디어 장치에 대한 권한 없을 때 대응 

### DIFF
--- a/frontend/src/components/session/SessionSidebar.tsx
+++ b/frontend/src/components/session/SessionSidebar.tsx
@@ -8,9 +8,9 @@ interface Props {
 
 const SessionSidebar = ({ question, participants }: Props) => {
   return (
-    <div className={"flex flex-col justify-between w-[440px] px-6"}>
+    <div className={"flex flex-col justify-between w-[440px] px-6 bg-white"}>
       <div className={"flex flex-col gap-4"}>
-        <div className={"flex flex-col gap-2"}>
+        <div className={"flex flex-col gap-2 pt-6"}>
           <h2 className={"inline-flex gap-1 items-center text-semibold-s"}>
             <FaClipboardList />
             질문

--- a/frontend/src/components/session/VideoContainer.tsx
+++ b/frontend/src/components/session/VideoContainer.tsx
@@ -32,6 +32,23 @@ const VideoContainer = ({
         return "";
     }
   };
+
+  const renderMicIcon = () => {
+    return isMicOn ? (
+      <BsMic className="text-white" />
+    ) : (
+      <BsMicMute className="text-red-500" />
+    );
+  };
+
+  const renderVideoIcon = () => {
+    return isVideoOn ? (
+      <BsCameraVideo className="text-white" />
+    ) : (
+      <BsCameraVideoOff className="text-red-500" />
+    );
+  };
+
   return (
     <div className="relative flex-grow max-w-4xl">
       <div className="bg-black rounded-2xl overflow-hidden shadow">
@@ -41,16 +58,8 @@ const VideoContainer = ({
             {isLocal && "Me"} {nickname}
           </p>
           <div className={"inline-flex gap-4 px-2 items-center"}>
-            {isMicOn ? (
-              <BsMic className="text-white" />
-            ) : (
-              <BsMicMute className="text-red-500" />
-            )}
-            {isVideoOn ? (
-              <BsCameraVideo className="text-white" />
-            ) : (
-              <BsCameraVideoOff className="text-red-500" />
-            )}
+            {renderMicIcon()}
+            {renderVideoIcon()}
           </div>
         </div>
       </div>

--- a/frontend/src/components/session/VideoContainer.tsx
+++ b/frontend/src/components/session/VideoContainer.tsx
@@ -23,9 +23,8 @@ const VideoContainer = ({
   reaction,
   stream,
 }: VideoContainerProps) => {
-  const renderReaction = (reaction: string) => {
-    console.log(reaction);
-    switch (reaction) {
+  const renderReaction = (reactionType: string) => {
+    switch (reactionType) {
       case "thumbs_up":
         return "👍";
       case "":

--- a/frontend/src/components/session/VideoContainer.tsx
+++ b/frontend/src/components/session/VideoContainer.tsx
@@ -1,4 +1,3 @@
-import { forwardRef } from "react";
 import {
   BsMic,
   BsMicMute,
@@ -16,50 +15,49 @@ interface VideoContainerProps {
   stream: MediaStream;
 }
 
-const VideoContainer = forwardRef(
-  ({
-    nickname,
-    isMicOn,
-    isVideoOn,
-    isLocal,
-    reaction,
-    stream,
-  }: VideoContainerProps) => {
-    const renderReaction = (reaction: string) => {
-      console.log(reaction);
-      switch (reaction) {
-        case "thumbs_up":
-          return "👍";
-        case "":
-        default:
-          return "";
-      }
-    };
-    return (
-      <div className="relative flex-grow max-w-4xl">
-        <div className="bg-black rounded-2xl overflow-hidden shadow">
-          <DisplayMediaStream mediaStream={stream} isLocal={isLocal} />
-          <div className="inline-flex gap-4 absolute bottom-2 w-full justify-between px-2">
-            <p className="bg-grayscale-500 bg-opacity-50 text-white px-2 py-0.5 rounded">
-              {isLocal && "Me"} {nickname}
-            </p>
-            <div className={"inline-flex gap-4 px-2 items-center"}>
-              {isMicOn ? (
-                <BsMic className="text-white" />
-              ) : (
-                <BsMicMute className="text-red-500" />
-              )}
-              {isVideoOn ? (
-                <BsCameraVideo className="text-white" />
-              ) : (
-                <BsCameraVideoOff className="text-red-500" />
-              )}
-            </div>
+const VideoContainer = ({
+  nickname,
+  isMicOn,
+  isVideoOn,
+  isLocal,
+  reaction,
+  stream,
+}: VideoContainerProps) => {
+  const renderReaction = (reaction: string) => {
+    console.log(reaction);
+    switch (reaction) {
+      case "thumbs_up":
+        return "👍";
+      case "":
+      default:
+        return "";
+    }
+  };
+  return (
+    <div className="relative flex-grow max-w-4xl">
+      <div className="bg-black rounded-2xl overflow-hidden shadow">
+        <DisplayMediaStream mediaStream={stream} isLocal={isLocal} />
+        <div className="inline-flex gap-4 absolute bottom-2 w-full justify-between px-2">
+          <p className="bg-grayscale-500 bg-opacity-50 text-white px-2 py-0.5 rounded">
+            {isLocal && "Me"} {nickname}
+          </p>
+          <div className={"inline-flex gap-4 px-2 items-center"}>
+            {isMicOn ? (
+              <BsMic className="text-white" />
+            ) : (
+              <BsMicMute className="text-red-500" />
+            )}
+            {isVideoOn ? (
+              <BsCameraVideo className="text-white" />
+            ) : (
+              <BsCameraVideoOff className="text-red-500" />
+            )}
           </div>
         </div>
-        {
-          <div
-            className={`
+      </div>
+      {
+        <div
+          className={`
               pointer-events-none
               absolute w-12 h-12 text-xl 
               flex items-center justify-center 
@@ -69,13 +67,12 @@ const VideoContainer = forwardRef(
               animate-fade-in-out
               ${reaction ? "opacity-100" : "opacity-0"}
             `}
-          >
-            <span className="animate-bounce">{renderReaction(reaction)}</span>
-          </div>
-        }
-      </div>
-    );
-  }
-);
+        >
+          <span className="animate-bounce">{renderReaction(reaction)}</span>
+        </div>
+      }
+    </div>
+  );
+};
 
 export default VideoContainer;

--- a/frontend/src/hooks/useMediaDevices.ts
+++ b/frontend/src/hooks/useMediaDevices.ts
@@ -17,6 +17,9 @@ const useMediaDevices = () => {
 
   // 본인 미디어 스트림
   const [stream, setStream] = useState<MediaStream | null>(null);
+  // 미디어 온오프 상태
+  const [isVideoOn, setIsVideoOn] = useState<boolean>(true);
+  const [isMicOn, setIsMicOn] = useState<boolean>(true);
 
   useEffect(() => {
     // 비디오 디바이스 목록 가져오기
@@ -74,15 +77,47 @@ const useMediaDevices = () => {
     }
   };
 
+  // 미디어 스트림 토글 관련
+  const handleVideoToggle = () => {
+    try {
+      // 비디오 껐다키기
+      if (stream) {
+        stream.getVideoTracks().forEach((videoTrack) => {
+          videoTrack.enabled = !videoTrack.enabled;
+        });
+      }
+      setIsVideoOn((prev) => !prev);
+    } catch (error) {
+      console.error("Error stopping video stream", error);
+    }
+  };
+
+  const handleMicToggle = () => {
+    try {
+      if (stream) {
+        stream.getAudioTracks().forEach((audioTrack) => {
+          audioTrack.enabled = !audioTrack.enabled;
+        });
+      }
+      setIsMicOn((prev) => !prev);
+    } catch (error) {
+      console.error("Error stopping mic stream", error);
+    }
+  };
+
   return {
     userAudioDevices,
     userVideoDevices,
     selectedAudioDeviceId,
     selectedVideoDeviceId,
+    stream,
+    isVideoOn,
+    isMicOn,
+    handleMicToggle,
+    handleVideoToggle,
     setSelectedAudioDeviceId,
     setSelectedVideoDeviceId,
     getMedia,
-    stream,
   };
 };
 

--- a/frontend/src/hooks/useMediaDevices.ts
+++ b/frontend/src/hooks/useMediaDevices.ts
@@ -20,7 +20,6 @@ const useMediaDevices = () => {
 
   useEffect(() => {
     // 비디오 디바이스 목록 가져오기
-
     const getUserDevices = async () => {
       try {
         const devices = await navigator.mediaDevices.enumerateDevices();
@@ -30,9 +29,15 @@ const useMediaDevices = () => {
         const videoDevices = devices.filter(
           (device) => device.kind === "videoinput"
         );
-
-        setUserAudioDevices(audioDevices);
-        setUserVideoDevices(videoDevices);
+        const dontHavePermission =
+          devices.find((device) => device.deviceId !== "") === undefined;
+        if (dontHavePermission) {
+          setUserAudioDevices([]);
+          setUserVideoDevices([]);
+        } else {
+          setUserAudioDevices(audioDevices);
+          setUserVideoDevices(videoDevices);
+        }
       } catch (error) {
         console.error("미디어 기기를 찾는데 문제가 발생했습니다.", error);
       }

--- a/frontend/src/hooks/usePeerConnection.ts
+++ b/frontend/src/hooks/usePeerConnection.ts
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useState } from "react";
+import { Socket } from "socket.io-client";
+
+interface User {
+  id?: string;
+  nickname: string;
+}
+
+interface PeerConnection {
+  peerId: string; // 연결된 상대의 ID
+  peerNickname: string; // 상대의 닉네임
+  stream: MediaStream; // 상대방의 비디오/오디오 스트림
+  reaction?: string;
+}
+
+// 피어 간 연결 수립 역할을 하는 커스텀 훅
+const usePeerConnection = (socket: Socket) => {
+  const [peers, setPeers] = useState<PeerConnection[]>([]); // 연결 관리
+  const peerConnections = useRef<{ [key: string]: RTCPeerConnection }>({});
+
+  // STUN 서버 설정
+  const pcConfig = {
+    iceServers: [
+      {
+        urls: import.meta.env.VITE_STUN_SERVER_URL,
+        username: import.meta.env.VITE_STUN_USER_NAME,
+        credential: import.meta.env.VITE_STUN_CREDENTIAL,
+      },
+    ],
+  };
+
+  useEffect(() => {
+    if (!socket) {
+      console.error("usePeerConnection: 소켓이 필요합니다.");
+    }
+  }, [socket]);
+
+  // Peer Connection 생성
+  const createPeerConnection = (
+    peerSocketId: string,
+    peerNickname: string,
+    stream: MediaStream,
+    isOffer: boolean,
+    localUser: User
+  ) => {
+    try {
+      // 유저 사이의 통신 선로를 생성
+      // STUN: 공개 주소를 알려주는 서버
+      // ICE: 두 피어 간의 최적의 경로를 찾아줌
+      const pc = new RTCPeerConnection(pcConfig);
+
+      // 로컬 스트림 추가: 내 카메라/마이크를 통신 선로(pc)에 연결
+      // 상대방에게 나의 비디오/오디오를 전송할 준비
+      stream.getTracks().forEach((track) => {
+        pc.addTrack(track, stream);
+      });
+
+      // ICE candidate 이벤트 처리
+      // 가능한 연결 경로를 찾을 때마다 상대에게 알려줌
+      pc.onicecandidate = (e: RTCPeerConnectionIceEvent) => {
+        if (e.candidate && socket) {
+          socket.emit("candidate", {
+            candidateReceiveID: peerSocketId,
+            candidate: e.candidate,
+            candidateSendID: socket.id,
+          });
+        }
+      };
+
+      // 연결 상태 모니터링
+      // 새로운 연결/연결 시도/연결 완료/연결 끊김/연결 실패/연결 종료
+      pc.onconnectionstatechange = () => {
+        console.log("연결 상태 변경:", pc.connectionState);
+      };
+      // ICE 연결 상태 모니터링
+      pc.oniceconnectionstatechange = () => {
+        console.log("ICE 연결 상태 변경:", pc.iceConnectionState);
+      };
+
+      // 원격 스트림 처리(상대가 addTrack을 호출할 때)
+      // 상대의 비디오/오디오 신호를 받아 연결하는 과정
+      // 상대방 스트림 수신 -> 기존 연결인지 확인 -> 스트림 정보 업데이트/추가
+      pc.ontrack = (e) => {
+        console.log("Received remote track:", e.streams[0]);
+        setPeers((prev) => {
+          // 이미 존재하는 피어인지 확인
+          const exists = prev.find((p) => p.peerId === peerSocketId);
+          if (exists) {
+            // 기존 피어의 스트림 업데이트
+            return prev.map((p) =>
+              p.peerId === peerSocketId ? { ...p, stream: e.streams[0] } : p
+            );
+          }
+          // 새로운 피어 추가
+          return [
+            ...prev,
+            {
+              peerId: peerSocketId,
+              peerNickname,
+              stream: e.streams[0],
+            },
+          ];
+        });
+      };
+
+      // Offer를 생성해야 하는 경우에만 Offer 생성
+      // Offer: 초대 - Offer 생성 -> 자신의 설정 저장 -> 상대에게 전송
+      if (isOffer) {
+        pc.createOffer()
+          .then((offer) => pc.setLocalDescription(offer))
+          .then(() => {
+            if (socket && pc.localDescription) {
+              socket.emit("offer", {
+                offerReceiveID: peerSocketId,
+                sdp: pc.localDescription,
+                offerSendID: socket.id,
+                offerSendNickname: localUser.nickname,
+              });
+            }
+          })
+          .catch((error) => console.error("Error creating offer:", error));
+      }
+
+      peerConnections.current[peerSocketId] = pc;
+      return pc;
+    } catch (error) {
+      console.error("Error creating peer connection:", error);
+      return null;
+    }
+  };
+
+  const closePeerConnection = (peerSocketId: string) => {
+    if (peerConnections.current[peerSocketId]) {
+      // 연결 종료
+      peerConnections.current[peerSocketId].close();
+      // 연결 객체 제거
+      delete peerConnections.current[peerSocketId];
+      // UI에서 사용자 제거
+      setPeers((prev) => prev.filter((peer) => peer.peerId !== peerSocketId));
+    }
+  };
+
+  return {
+    peers,
+    setPeers,
+    peerConnections,
+    createPeerConnection,
+    closePeerConnection,
+  };
+};
+
+export default usePeerConnection;

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -433,7 +433,6 @@ const SessionPage = () => {
             </h1>
             <div className={"speaker max-w-4xl px-6 flex w-full"}>
               <VideoContainer
-                ref={myVideoRef}
                 nickname={nickname}
                 isMicOn={isMicOn}
                 isVideoOn={isVideoOn}

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -6,22 +6,22 @@ import SessionSidebar from "../components/session/SessionSidebar.tsx";
 import SessionToolbar from "../components/session/SessionToolbar.tsx";
 import useMediaDevices from "../hooks/useMediaDevices.ts";
 import useToast from "../hooks/useToast.ts";
+import usePeerConnection from "../hooks/usePeerConnection.ts";
 
 interface User {
   id: string;
   nickname: string;
 }
 
-interface PeerConnection {
-  peerId: string; // 연결된 상대의 ID
-  peerNickname: string; // 상대의 닉네임
-  stream: MediaStream; // 상대방의 비디오/오디오 스트림
-  reaction?: string;
-}
-
 const SessionPage = () => {
   const { socket } = useSocket(import.meta.env.VITE_SIGNALING_SERVER_URL);
-  const [peers, setPeers] = useState<PeerConnection[]>([]); // 연결 관리
+  const {
+    createPeerConnection,
+    closePeerConnection,
+    peers,
+    setPeers,
+    peerConnections,
+  } = usePeerConnection(socket!);
   const [roomId, setRoomId] = useState<string>("");
   const [nickname, setNickname] = useState<string>("");
   const [reaction, setReaction] = useState("");
@@ -44,20 +44,8 @@ const SessionPage = () => {
   const reactionTimeouts = useRef<{
     [key: string]: ReturnType<typeof setTimeout>;
   }>({});
-  const peerConnections = useRef<{ [key: string]: RTCPeerConnection }>({});
   const navigate = useNavigate();
   const toast = useToast();
-
-  // STUN 서버 설정
-  const pcConfig = {
-    iceServers: [
-      {
-        urls: import.meta.env.VITE_STUN_SERVER_URL,
-        username: import.meta.env.VITE_STUN_USER_NAME,
-        credential: import.meta.env.VITE_STUN_CREDENTIAL,
-      },
-    ],
-  };
 
   useEffect(() => {
     const connections = peerConnections;
@@ -111,7 +99,7 @@ const SessionPage = () => {
     };
   }, [socket]);
 
-  const handleReaction = (reactionType: string) => {
+  const emitReaction = (reactionType: string) => {
     if (socket) {
       socket.emit("reaction", {
         roomId: roomId,
@@ -148,7 +136,9 @@ const SessionPage = () => {
     // 기존 사용자들의 정보 수신: 방에 있던 사용자들과 createPeerConnection 생성
     socket.on("all_users", (users: User[]) => {
       users.forEach((user) => {
-        createPeerConnection(user.id, user.nickname, stream, true);
+        createPeerConnection(user.id, user.nickname, stream, true, {
+          nickname,
+        });
       });
     });
 
@@ -166,7 +156,8 @@ const SessionPage = () => {
           data.offerSendID,
           data.offerSendNickname,
           stream,
-          false
+          false,
+          { nickname }
         );
         if (!pc) return;
 
@@ -225,14 +216,7 @@ const SessionPage = () => {
 
     // 사용자 퇴장 처리
     socket.on("user_exit", ({ id }: { id: string }) => {
-      if (peerConnections.current[id]) {
-        // 연결 종료
-        peerConnections.current[id].close();
-        // 연결 객체 제거
-        delete peerConnections.current[id];
-        // UI에서 사용자 제거
-        setPeers((prev) => prev.filter((peer) => peer.peerId !== id));
-      }
+      closePeerConnection(id);
     });
 
     socket.on(
@@ -242,9 +226,8 @@ const SessionPage = () => {
           clearTimeout(reactionTimeouts.current[senderId]);
         }
 
-        if (senderId === socket.id) {
+        if (senderId === socket!.id) {
           setReaction(reaction);
-
           reactionTimeouts.current[senderId] = setTimeout(() => {
             setReaction("");
             delete reactionTimeouts.current[senderId];
@@ -267,99 +250,6 @@ const SessionPage = () => {
       )
     );
   }, []);
-
-  // Peer Connection 생성
-  const createPeerConnection = (
-    peerSocketId: string,
-    peerNickname: string,
-    stream: MediaStream,
-    isOffer: boolean
-  ) => {
-    try {
-      // 유저 사이의 통신 선로를 생성
-      // STUN: 공개 주소를 알려주는 서버
-      // ICE: 두 피어 간의 최적의 경로를 찾아줌
-      const pc = new RTCPeerConnection(pcConfig);
-
-      // 로컬 스트림 추가: 내 카메라/마이크를 통신 선로(pc)에 연결
-      // 상대방에게 나의 비디오/오디오를 전송할 준비
-      stream.getTracks().forEach((track) => {
-        pc.addTrack(track, stream);
-      });
-
-      // ICE candidate 이벤트 처리
-      // 가능한 연결 경로를 찾을 때마다 상대에게 알려줌
-      pc.onicecandidate = (e) => {
-        if (e.candidate && socket) {
-          socket.emit("candidate", {
-            candidateReceiveID: peerSocketId,
-            candidate: e.candidate,
-            candidateSendID: socket.id,
-          });
-        }
-      };
-
-      // 연결 상태 모니터링
-      // 새로운 연결/연결 시도/연결 완료/연결 끊김/연결 실패/연결 종료
-      pc.onconnectionstatechange = () => {
-        console.log("연결 상태 변경:", pc.connectionState);
-      };
-      // ICE 연결 상태 모니터링
-      pc.oniceconnectionstatechange = () => {
-        console.log("ICE 연결 상태 변경:", pc.iceConnectionState);
-      };
-
-      // 원격 스트림 처리(상대가 addTrack을 호출할 때)
-      // 상대의 비디오/오디오 신호를 받아 연결하는 과정
-      // 상대방 스트림 수신 -> 기존 연결인지 확인 -> 스트림 정보 업데이트/추가
-      pc.ontrack = (e) => {
-        console.log("Received remote track:", e.streams[0]);
-        setPeers((prev) => {
-          // 이미 존재하는 피어인지 확인
-          const exists = prev.find((p) => p.peerId === peerSocketId);
-          if (exists) {
-            // 기존 피어의 스트림 업데이트
-            return prev.map((p) =>
-              p.peerId === peerSocketId ? { ...p, stream: e.streams[0] } : p
-            );
-          }
-          // 새로운 피어 추가
-          return [
-            ...prev,
-            {
-              peerId: peerSocketId,
-              peerNickname,
-              stream: e.streams[0],
-            },
-          ];
-        });
-      };
-
-      // Offer를 생성해야 하는 경우에만 Offer 생성
-      // Offer: 초대 - Offer 생성 -> 자신의 설정 저장 -> 상대에게 전송
-      if (isOffer) {
-        pc.createOffer()
-          .then((offer) => pc.setLocalDescription(offer))
-          .then(() => {
-            if (socket && pc.localDescription) {
-              socket.emit("offer", {
-                offerReceiveID: peerSocketId,
-                sdp: pc.localDescription,
-                offerSendID: socket.id,
-                offerSendNickname: nickname,
-              });
-            }
-          })
-          .catch((error) => console.error("Error creating offer:", error));
-      }
-
-      peerConnections.current[peerSocketId] = pc;
-      return pc;
-    } catch (error) {
-      console.error("Error creating peer connection:", error);
-      return null;
-    }
-  };
 
   return (
     <section className="w-screen h-screen flex flex-col max-w-[1440px]">
@@ -435,7 +325,7 @@ const SessionPage = () => {
           <SessionToolbar
             handleVideoToggle={handleVideoToggle}
             handleMicToggle={handleMicToggle}
-            handleReaction={handleReaction}
+            handleReaction={emitReaction}
             userVideoDevices={userVideoDevices}
             userAudioDevices={userAudioDevices}
             setSelectedVideoDeviceId={setSelectedVideoDeviceId}

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -5,6 +5,7 @@ import useSocket from "../hooks/useSocket.ts";
 import SessionSidebar from "../components/session/SessionSidebar.tsx";
 import SessionToolbar from "../components/session/SessionToolbar.tsx";
 import useMediaDevices from "../hooks/useMediaDevices.ts";
+import useToast from "../hooks/useToast.ts";
 
 interface User {
   id: string;
@@ -45,6 +46,7 @@ const SessionPage = () => {
   }>({});
   const peerConnections = useRef<{ [key: string]: RTCPeerConnection }>({});
   const navigate = useNavigate();
+  const toast = useToast();
 
   // STUN 서버 설정
   const pcConfig = {
@@ -120,11 +122,14 @@ const SessionPage = () => {
 
   // 방 입장 처리: 사용자가 join room 버튼을 클릭할 때
   const joinRoom = async () => {
-    if (!socket || !roomId || !nickname) return;
+    if (!socket || !roomId || !nickname) {
+      toast.error("방 번호와 닉네임을 입력해주세요.");
+      return;
+    }
 
     const stream = await getMedia();
     if (!stream) {
-      alert(
+      toast.error(
         "미디어 스트림을 가져오지 못했습니다. 미디어 장치를 확인 후 다시 시도해주세요."
       );
       navigate("/sessions");
@@ -134,8 +139,7 @@ const SessionPage = () => {
     socket.emit("join_room", { room: roomId, nickname });
 
     socket.on("room_full", () => {
-      console.log("방이 꽉찼심");
-      alert(
+      toast.error(
         "해당 세션은 이미 유저가 가득 찼습니다. 세션 페이지로 이동합니다..."
       );
       navigate("/sessions");

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -24,18 +24,20 @@ const SessionPage = () => {
   const [roomId, setRoomId] = useState<string>("");
   const [nickname, setNickname] = useState<string>("");
   const [reaction, setReaction] = useState("");
-  const [isVideoOn, setIsVideoOn] = useState<boolean>(true);
-  const [isMicOn, setIsMicOn] = useState<boolean>(true);
 
   const {
     userVideoDevices,
     userAudioDevices,
     selectedAudioDeviceId,
     selectedVideoDeviceId,
+    stream: myStream,
+    isVideoOn,
+    isMicOn,
+    handleMicToggle,
+    handleVideoToggle,
     setSelectedAudioDeviceId,
     setSelectedVideoDeviceId,
     getMedia,
-    stream: myStream,
   } = useMediaDevices();
 
   const reactionTimeouts = useRef<{
@@ -110,34 +112,6 @@ const SessionPage = () => {
       myVideoRef.current.srcObject = myStream;
     }
   }, [myStream]);
-
-  // 미디어 스트림 토글 관련
-  const handleVideoToggle = () => {
-    try {
-      // 비디오 껐다키기
-      if (myStream) {
-        myStream.getVideoTracks().forEach((videoTrack) => {
-          videoTrack.enabled = !videoTrack.enabled;
-        });
-      }
-      setIsVideoOn((prev) => !prev);
-    } catch (error) {
-      console.error("Error stopping video stream", error);
-    }
-  };
-
-  const handleMicToggle = () => {
-    try {
-      if (myStream) {
-        myStream.getAudioTracks().forEach((audioTrack) => {
-          audioTrack.enabled = !audioTrack.enabled;
-        });
-      }
-      setIsMicOn((prev) => !prev);
-    } catch (error) {
-      console.error("Error stopping mic stream", error);
-    }
-  };
 
   const handleReaction = (reactionType: string) => {
     if (socket) {

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -61,7 +61,7 @@ const SessionPage = () => {
         pc.close();
       });
     };
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     // 미디어 스트림 정리 로직
@@ -249,7 +249,7 @@ const SessionPage = () => {
         peer.peerId === senderId ? { ...peer, reaction: reactionType } : peer
       )
     );
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <section className="w-screen h-screen flex flex-col max-w-[1440px]">

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -253,7 +253,7 @@ const SessionPage = () => {
 
   return (
     <section className="w-screen h-screen flex flex-col max-w-[1440px]">
-      <div className="w-screen flex gap-2 mb-4 space-y-2">
+      <div className="w-screen flex gap-2 mb-4 space-y-2 ">
         <input
           type="text"
           placeholder="Room ID"

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import VideoContainer from "../components/session/VideoContainer.tsx";
 import { useNavigate } from "react-router-dom";
 import useSocket from "../hooks/useSocket.ts";
@@ -260,13 +260,13 @@ const SessionPage = () => {
     );
   };
 
-  const addReaction = (senderId: string, reactionType: string) => {
+  const addReaction = useCallback((senderId: string, reactionType: string) => {
     setPeers((prev) =>
       prev.map((peer) =>
         peer.peerId === senderId ? { ...peer, reaction: reactionType } : peer
       )
     );
-  };
+  }, []);
 
   // Peer Connection 생성
   const createPeerConnection = (

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -93,6 +93,11 @@ const SessionPage = () => {
     // 메모리 누수, 중복 실행을 방지하기 위해 정리
     return () => {
       if (socket) {
+        if (reactionTimeouts.current) {
+          for (const value of Object.values(reactionTimeouts.current)) {
+            clearTimeout(value);
+          }
+        }
         socket.off("room_full");
         socket.off("all_users");
         socket.off("getOffer");

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -43,9 +43,7 @@ const SessionPage = () => {
   const reactionTimeouts = useRef<{
     [key: string]: ReturnType<typeof setTimeout>;
   }>({});
-  const myVideoRef = useRef<HTMLVideoElement | null>(null);
   const peerConnections = useRef<{ [key: string]: RTCPeerConnection }>({});
-  // const peerVideoRefs = useRef<{ [key: string]: HTMLVideoElement | null }>({});
   const navigate = useNavigate();
 
   // STUN 서버 설정
@@ -105,13 +103,6 @@ const SessionPage = () => {
       }
     };
   }, [socket]);
-
-  // 미디어 스트림 가져오기
-  useEffect(() => {
-    if (myStream && myVideoRef.current) {
-      myVideoRef.current.srcObject = myStream;
-    }
-  }, [myStream]);
 
   const handleReaction = (reactionType: string) => {
     if (socket) {
@@ -360,8 +351,6 @@ const SessionPage = () => {
       return null;
     }
   };
-
-  // 공감 기능 관련
 
   return (
     <section className="w-screen h-screen flex flex-col max-w-[1440px]">


### PR DESCRIPTION
> [!NOTE]
> 작성자: 서정우
> 작성 날짜: 2024.11.12
> 
> 세션 페이지 코드가 길어서 조금씩 분리를 해보고 있습니다. 이제 RTC Offer/Answer 부분 정도만 분리하면 될 것 같습니다. 이번엔 PeerConnection을 생성하는 부분과 관리를 맡긴 커스텀 훅을 만들었습니다.


## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- 세션 페이지 리팩토링
- P2P 커넥션 생성 및 제거 커스텀 훅으로 분리
- 미디어 권한 없을 때 대응 추가

## 📝 작업 상세 내역
### usePeerConnection 훅
- 세션 페이지 코드가 길어서 조금씩 분리를 하고 있다. 
- 피어커넥션 상태
- 피어커넥션 수립 및 제거 함수

### 미디어 권한 없을 때 대응
- 미디어 장치에 권한이 없을 때 미디어 장치를 불러오면?
- 빈 배열로 오는 것도 아니고, 오류가 나는 것도 아니다.
- 미디어 장치의 수 만큼 장치 정보는 오지만, 장치의 이름과 id 등이 모두 빈 문자열로 치환되어서 내려온다.
- 해당 사실을 알게 되어 그에 맞게 수정했다. 

## 💬 다음 작업 또는 논의 사항
- 아직 세션에 대한 기능이 구현되지 않아 리팩토링을 진행했습니다.
- 커스텀 훅 분리가 생각보다 어렵네요