### PR TITLE
[Fix] 카메라를 꺼도 인디케이터가 켜져있던 문제 해결

### DIFF
--- a/frontend/src/hooks/useMediaDevices.ts
+++ b/frontend/src/hooks/useMediaDevices.ts
@@ -1,4 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+
+type MediaStreamType = "video" | "audio";
 
 const useMediaDevices = () => {
   // 유저의 미디어 장치 리스트
@@ -17,6 +19,9 @@ const useMediaDevices = () => {
 
   // 본인 미디어 스트림
   const [stream, setStream] = useState<MediaStream | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const [videoLoading, setVideoLoading] = useState<boolean>(false);
+
   // 미디어 온오프 상태
   const [isVideoOn, setIsVideoOn] = useState<boolean>(true);
   const [isMicOn, setIsMicOn] = useState<boolean>(true);
@@ -52,11 +57,12 @@ const useMediaDevices = () => {
   // 미디어 스트림 가져오기: 자신의 스트림을 가져옴
   const getMedia = async () => {
     try {
-      if (stream) {
+      if (streamRef.current) {
         // 이미 스트림이 있으면 종료
-        stream.getTracks().forEach((track) => {
+        streamRef.current.getTracks().forEach((track) => {
           track.stop();
         });
+        setStream(null);
       }
       const myStream = await navigator.mediaDevices.getUserMedia({
         video: selectedVideoDeviceId
@@ -67,6 +73,7 @@ const useMediaDevices = () => {
           : true,
       });
 
+      streamRef.current = myStream;
       setStream(myStream);
       return myStream;
     } catch (error) {
@@ -77,14 +84,57 @@ const useMediaDevices = () => {
     }
   };
 
+  // 특정 미디어 스트림만 가져오는 함수
+  const getMediaStream = async (mediaType: MediaStreamType) => {
+    try {
+      return navigator.mediaDevices.getUserMedia(
+        mediaType === "audio"
+          ? {
+              audio: selectedAudioDeviceId
+                ? { deviceId: selectedAudioDeviceId }
+                : true,
+            }
+          : {
+              video: selectedVideoDeviceId
+                ? { deviceId: selectedVideoDeviceId }
+                : true,
+            }
+      );
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
   // 미디어 스트림 토글 관련
-  const handleVideoToggle = () => {
+  const handleVideoToggle = async () => {
     try {
       // 비디오 껐다키기
+
       if (stream) {
-        stream.getVideoTracks().forEach((videoTrack) => {
-          videoTrack.enabled = !videoTrack.enabled;
-        });
+        for (const videoTrack of stream.getVideoTracks()) {
+          if (videoTrack.enabled) {
+            // 비디오 끄기
+            videoTrack.stop();
+            videoTrack.enabled = false;
+          } else {
+            // 새로운 비디오 스트림 생성
+            const videoStream = await getMediaStream("video");
+            if (videoStream) {
+              setVideoLoading(true);
+              streamRef.current?.getVideoTracks().forEach((track) => {
+                streamRef.current?.removeTrack(track);
+              });
+              videoStream?.getVideoTracks().forEach((track) => {
+                streamRef.current?.addTrack(track);
+                console.log("새로운 비디오 트랙을 추가했습니다.");
+              });
+            } else {
+              console.error("비디오 스트림을 생성하지 못했습니다.");
+            }
+            setVideoLoading(false);
+            setStream(streamRef.current);
+          }
+        }
       }
       setIsVideoOn((prev) => !prev);
     } catch (error) {
@@ -92,12 +142,31 @@ const useMediaDevices = () => {
     }
   };
 
-  const handleMicToggle = () => {
+  const handleMicToggle = async () => {
     try {
       if (stream) {
-        stream.getAudioTracks().forEach((audioTrack) => {
-          audioTrack.enabled = !audioTrack.enabled;
-        });
+        for (const audioTrack of stream.getAudioTracks()) {
+          if (audioTrack.enabled) {
+            // 오디오 끄기
+            audioTrack.stop();
+            audioTrack.enabled = false;
+          } else {
+            // 새로운 오디오 스트림 생성
+            const audioStream = await getMediaStream("audio");
+            if (audioStream) {
+              streamRef.current?.getAudioTracks().forEach((track) => {
+                streamRef.current?.removeTrack(track);
+              });
+              audioStream?.getAudioTracks().forEach((track) => {
+                streamRef.current?.addTrack(track);
+                console.log("새로운 오디오 트랙을 추가했습니다.");
+              });
+            } else {
+              console.error("오디오 스트림을 생성하지 못했습니다.");
+            }
+            setStream(streamRef.current);
+          }
+        }
       }
       setIsMicOn((prev) => !prev);
     } catch (error) {
@@ -113,6 +182,7 @@ const useMediaDevices = () => {
     stream,
     isVideoOn,
     isMicOn,
+    videoLoading,
     handleMicToggle,
     handleVideoToggle,
     setSelectedAudioDeviceId,

--- a/frontend/src/hooks/usePeerConnection.ts
+++ b/frontend/src/hooks/usePeerConnection.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Socket } from "socket.io-client";
 
 interface User {
@@ -28,12 +28,6 @@ const usePeerConnection = (socket: Socket) => {
       },
     ],
   };
-
-  useEffect(() => {
-    if (!socket) {
-      console.error("usePeerConnection: 소켓이 필요합니다.");
-    }
-  }, [socket]);
 
   // Peer Connection 생성
   const createPeerConnection = (

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -10,8 +10,8 @@ const useSocket = (socketURL: string) => {
     const newSocket = io(socketURL || "http://localhost:3000");
 
     newSocket.on("connect_error", socketErrorHandler);
+    newSocket.on("connect", socketConnectHandler);
     setSocket(newSocket);
-
     return () => {
       newSocket.disconnect();
       setSocket(null);
@@ -19,6 +19,10 @@ const useSocket = (socketURL: string) => {
   }, [socketURL]);
 
   return { socket };
+};
+
+const socketConnectHandler = () => {
+  console.log("시그널링 서버와 연결되었습니다.");
 };
 
 const socketErrorHandler = (error: Error) => {

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -31,7 +31,7 @@ const SessionPage = () => {
     userAudioDevices,
     selectedAudioDeviceId,
     selectedVideoDeviceId,
-    stream: myStream,
+    stream,
     isVideoOn,
     isMicOn,
     handleMicToggle,
@@ -66,11 +66,11 @@ const SessionPage = () => {
   useEffect(() => {
     // 미디어 스트림 정리 로직
     return () => {
-      if (myStream) {
-        myStream.getTracks().forEach((track) => track.stop());
+      if (stream) {
+        stream.getTracks().forEach((track) => track.stop());
       }
     };
-  }, [myStream]);
+  }, [stream]);
 
   useEffect(() => {
     if (selectedAudioDeviceId || selectedVideoDeviceId) {
@@ -300,7 +300,7 @@ const SessionPage = () => {
                 isVideoOn={isVideoOn}
                 isLocal={true}
                 reaction={reaction || ""}
-                stream={myStream!}
+                stream={stream!}
               />
             </div>
             <div className={"listeners w-full flex gap-2 px-6"}>


### PR DESCRIPTION
> [!NOTE]
> 관련 이슈 번호: #111 
> 작성자: 서정우
> 작성 날짜: 2024.11.13


## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- #111 버그 해결
- 카메라/마이크 끄고 켤때 새로운 미디어 스트림을 생성하도록 변경

## 📝 작업 상세 내역
### 미디어 장치 토글 기능
- **카메라 인디케이터를 비활성화하고 다시켤때 스트림을 다시 얻어오는 작업**
- 이전에는 단순히 비활성화를 했다면 이번에는 **스트림을 새로 생성하기 때문에 약간의 지연시간**이 생겼다.

## 📌 테스트 및 검증 결과
![카메라인디케이터해결](https://github.com/user-attachments/assets/43bd5f4d-f27d-45a2-a5e2-8a18eed6cc44)

## 📎 참고 자료 (선택)
- [노션 개발 문서](https://alpine-tiglon-9f0.notion.site/13c696f85d1f8077af51d8ded17740a7?pvs=4)
