### PR TITLE
[Feat] 세션 만들기 후 방 입장 | 링크 공유해서 들어올 수 있게 설정

### DIFF
--- a/frontend/src/components/session/SessionSidebar.tsx
+++ b/frontend/src/components/session/SessionSidebar.tsx
@@ -10,7 +10,7 @@ interface Props {
   socket: Socket | null;
   question: string;
   participants: string[];
-  roomId: string;
+  roomId: string | undefined; // TODO: sessionId가 입력되지 않았을 때(undefined) 처리 필요
 }
 
 const SessionSidebar = ({ socket, question, participants, roomId }: Props) => {
@@ -32,7 +32,7 @@ const SessionSidebar = ({ socket, question, participants, roomId }: Props) => {
         leftButton="취소하기"
         rightButton="종료하기"
         type="red"
-        onLeftClick={() => {}}
+        onLeftClick={() => { }}
         onRightClick={existHandler}
       />
       <div className={"flex flex-col gap-4"}>

--- a/frontend/src/components/sessions/create/SessionForm/AccessSection/index.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/AccessSection/index.tsx
@@ -10,20 +10,22 @@ const AccessSection = () => {
       <div className="flex w-full h-11">
         <button
           className={`flex-grow rounded-l-custom-m border 
-          ${access === "public"
+          ${
+            access === "public"
               ? "text-semibold-r text-green-700 border-2 border-green-200 bg-green-50"
               : "text-medium-m text-gray-400 border-r-0"
-            }`}
+          }`}
           onClick={() => setAccess("public")}
         >
           공개
         </button>
         <button
           className={`flex-grow rounded-r-custom-m border
-          ${access === "private"
+          ${
+            access === "private"
               ? "text-semibold-r text-green-700 border-2 border-green-200 bg-green-50"
               : "text-medium-m text-gray-400 border-l-0"
-            }`}
+          }`}
           onClick={() => setAccess("private")}
         >
           비공개

--- a/frontend/src/components/sessions/create/SessionForm/ListSelectModal/QuestionList/QuestionItem.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/ListSelectModal/QuestionList/QuestionItem.tsx
@@ -67,9 +67,10 @@ const QuestionItem = ({ item }: { item: ListItem }) => {
         </div>
         <button
           className={`flex items-center ml-auto w-10 h-10 rounded-custom-m
-            ${isSelected
-              ? "bg-green-200 text-green-50"
-              : "bg-gray-300 text-gray-50"
+            ${
+              isSelected
+                ? "bg-green-200 text-green-50"
+                : "bg-gray-300 text-gray-50"
             }`}
           onClick={() => checkHandler(item.id, item.title)}
         >

--- a/frontend/src/components/sessions/create/SessionForm/ParticipantSection/ParticpantButton.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/ParticipantSection/ParticpantButton.tsx
@@ -11,10 +11,11 @@ const ParticipantButton = ({ selectedValue, onClick }: Props) => {
   return (
     <button
       className={`flex-grow rounded-custom-m
-      ${participant === selectedValue
+      ${
+        participant === selectedValue
           ? "bg-green-50 border-2 border-green-200 text-semibold-r text-green-600"
           : "bg-gray-white border border-gray-100 text-medium-m text-gray-400"
-        }`}
+      }`}
       onClick={onClick}
     >
       {selectedValue}명

--- a/frontend/src/components/sessions/create/SessionForm/index.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/index.tsx
@@ -1,4 +1,4 @@
-import AccessButton from "./AccessSection";
+import AccessSection from "./AccessSection";
 import CategorySection from "./CategorySection";
 import ParticipantSection from "./ParticipantSection";
 import NameSection from "./NameSection";
@@ -77,7 +77,7 @@ const SessionForm = () => {
       <NameSection />
       <QuestionListSection />
       <ParticipantSection />
-      <AccessButton />
+      <AccessSection />
       <button
         className={`w-full h-12 rounded-custom-m text-semibold-r text-gray-white
         ${isValid ? "bg-green-200" : "bg-gray-200"}

--- a/frontend/src/components/sessions/create/SessionForm/index.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/index.tsx
@@ -11,7 +11,7 @@ import { useCallback, useEffect } from "react";
 import useToast from "@/hooks/useToast";
 
 interface RoomCreatedResponse {
-  success: boolean;
+  success?: boolean;
   roomId?: string;
   error?: string;
 }
@@ -47,15 +47,17 @@ const SessionForm = () => {
       isPrivate: access === "private",
     };
 
-    // 현재는 title 데이터만 받음
-    socket?.emit("create_room", roomData.title);
+    socket?.emit("create_room", {
+      title: roomData.title,
+      maxParticipants: roomData.maxParticipant
+    });
   };
 
   useEffect(() => {
     if (!socket) return;
 
     const roomCreatedHandler = (response: RoomCreatedResponse) => {
-      if (response.success) {
+      if (response.roomId) {
         navigate(`/session/${response.roomId}`);
       } else {
         toast.error("방 생성에 실패하였습니다.");

--- a/frontend/src/components/sessions/create/SessionForm/index.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/index.tsx
@@ -49,7 +49,7 @@ const SessionForm = () => {
 
     socket?.emit("create_room", {
       title: roomData.title,
-      maxParticipants: roomData.maxParticipant
+      maxParticipants: roomData.maxParticipant,
     });
   };
 

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import VideoContainer from "@/components/session/VideoContainer.tsx";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import SessionSidebar from "@/components/session/SessionSidebar.tsx";
 import SessionToolbar from "@/components/session/SessionToolbar.tsx";
 import useMediaDevices from "@/hooks/useMediaDevices.ts";
@@ -25,7 +25,7 @@ const SessionPage = () => {
     setPeers,
     peerConnections,
   } = usePeerConnection(socket!);
-  const [roomId, setRoomId] = useState<string>("");
+  const { sessionId } = useParams();
   const [nickname, setNickname] = useState<string>("");
   const [reaction, setReaction] = useState("");
 
@@ -56,19 +56,16 @@ const SessionPage = () => {
 
     return () => {
       Object.values(connections.current).forEach((pc) => {
-        // 모든 이벤트 리스너 제거
         pc.ontrack = null;
         pc.onicecandidate = null;
         pc.oniceconnectionstatechange = null;
         pc.onconnectionstatechange = null;
-        // 연결 종료
         pc.close();
       });
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    // 미디어 스트림 정리 로직
     return () => {
       if (stream) {
         stream.getTracks().forEach((track) => track.stop());
@@ -83,44 +80,162 @@ const SessionPage = () => {
   }, [selectedAudioDeviceId, selectedVideoDeviceId]);
 
   useEffect(() => {
-    // socket 이벤트 리스너들 정리
-    // 메모리 누수, 중복 실행을 방지하기 위해 정리
-    return () => {
-      if (socket) {
-        if (reactionTimeouts.current) {
-          for (const value of Object.values(reactionTimeouts.current)) {
-            clearTimeout(value);
-          }
-        }
-        socket.off("room_full");
-        socket.off("all_users");
-        socket.off("getOffer");
-        socket.off("getAnswer");
-        socket.off("getCandidate");
-        socket.off("user_exit");
-        socket.off("reaction");
+    if (!socket || !stream) return;
+
+    console.log("Setting up socket event listeners");
+
+    const handleAllUsers = (users: User[]) => {
+      console.log("Received all_users:", users);
+      Object.entries(users).forEach(([socketId, userInfo]) => {
+        console.log("Creating peer connection for:", {
+          socketId,
+          nickname: userInfo.nickname,
+        });
+
+        createPeerConnection(socketId, userInfo.nickname, stream, true, {
+          nickname,
+        });
+      });
+    };
+
+    const handleGetOffer = async (data: {
+      sdp: RTCSessionDescription;
+      offerSendID: string;
+      offerSendNickname: string;
+    }) => {
+      console.log("Received offer from:", data.offerSendID);
+      const pc = createPeerConnection(
+        data.offerSendID,
+        data.offerSendNickname,
+        stream,
+        false,
+        { nickname }
+      );
+      if (!pc) return;
+
+      try {
+        await pc.setRemoteDescription(new RTCSessionDescription(data.sdp));
+        const answer = await pc.createAnswer();
+        await pc.setLocalDescription(answer);
+
+        socket.emit("answer", {
+          answerReceiveID: data.offerSendID,
+          sdp: answer,
+          answerSendID: socket.id,
+        });
+      } catch (error) {
+        console.error("Error handling offer:", error);
       }
     };
-  }, [socket]);
+
+    const handleGetAnswer = async (data: {
+      sdp: RTCSessionDescription;
+      answerSendID: string;
+    }) => {
+      console.log("Received answer from:", data.answerSendID);
+      const pc = peerConnections.current[data.answerSendID];
+      if (!pc) return;
+      try {
+        await pc.setRemoteDescription(new RTCSessionDescription(data.sdp));
+      } catch (error) {
+        console.error("Error handling answer:", error);
+      }
+    };
+
+    const handleGetCandidate = async (data: {
+      candidate: RTCIceCandidate;
+      candidateSendID: string;
+    }) => {
+      const pc = peerConnections.current[data.candidateSendID];
+      if (!pc) return;
+      try {
+        await pc.addIceCandidate(new RTCIceCandidate(data.candidate));
+      } catch (error) {
+        console.error("Error handling ICE candidate:", error);
+      }
+    };
+
+    const handleReaction = ({
+      senderId,
+      reaction,
+    }: {
+      senderId: string;
+      reaction: string;
+    }) => {
+      if (reactionTimeouts.current[senderId]) {
+        clearTimeout(reactionTimeouts.current[senderId]);
+      }
+
+      if (senderId === socket.id) {
+        setReaction(reaction);
+        reactionTimeouts.current[senderId] = setTimeout(() => {
+          setReaction("");
+          delete reactionTimeouts.current[senderId];
+        }, 3000);
+      } else {
+        addReaction(senderId, reaction);
+        reactionTimeouts.current[senderId] = setTimeout(() => {
+          addReaction(senderId, "");
+          delete reactionTimeouts.current[senderId];
+        }, 3000);
+      }
+    };
+
+    socket.on("all_users", handleAllUsers);
+    socket.on("getOffer", handleGetOffer);
+    socket.on("getAnswer", handleGetAnswer);
+    socket.on("getCandidate", handleGetCandidate);
+    socket.on("user_exit", ({ id }) => closePeerConnection(id));
+    socket.on("room_full", () => {
+      toast.error("해당 세션은 이미 유저가 가득 찼습니다.");
+      navigate("/sessions");
+    });
+    socket.on("reaction", handleReaction);
+
+    return () => {
+      console.log("Cleaning up socket event listeners");
+      socket.off("all_users", handleAllUsers);
+      socket.off("getOffer", handleGetOffer);
+      socket.off("getAnswer", handleGetAnswer);
+      socket.off("getCandidate", handleGetCandidate);
+      socket.off("user_exit");
+      socket.off("room_full");
+      socket.off("reaction", handleReaction);
+
+      if (reactionTimeouts.current) {
+        Object.values(reactionTimeouts.current).forEach((timeout) => {
+          clearTimeout(timeout);
+        });
+      }
+    };
+  }, [
+    socket,
+    stream,
+    nickname,
+    createPeerConnection,
+    closePeerConnection,
+    peerConnections,
+    navigate,
+    toast,
+  ]);
 
   const emitReaction = (reactionType: string) => {
     if (socket) {
       socket.emit("reaction", {
-        roomId: roomId,
+        roomId: sessionId,
         reaction: reactionType,
       });
     }
   };
 
-  // 방 입장 처리: 사용자가 join room 버튼을 클릭할 때
   const joinRoom = async () => {
-    if (!socket || !roomId || !nickname) {
-      toast.error("방 번호와 닉네임을 입력해주세요.");
+    if (!socket || !sessionId || !nickname) {
+      toast.error("닉네임을 입력해주세요.");
       return;
     }
 
-    const stream = await getMedia();
-    if (!stream) {
+    const mediaStream = await getMedia();
+    if (!mediaStream) {
       toast.error(
         "미디어 스트림을 가져오지 못했습니다. 미디어 장치를 확인 후 다시 시도해주세요."
       );
@@ -128,143 +243,22 @@ const SessionPage = () => {
       return;
     }
 
-    socket.emit("join_room", { room: roomId, nickname });
-
-    socket.on("room_full", () => {
-      toast.error(
-        "해당 세션은 이미 유저가 가득 찼습니다. 세션 페이지로 이동합니다..."
-      );
-      navigate("/sessions");
-      return;
-    });
-    // 기존 사용자들의 정보 수신: 방에 있던 사용자들과 createPeerConnection 생성
-    socket.on("all_users", (users: User[]) => {
-      users.forEach((user) => {
-        createPeerConnection(user.id, user.nickname, stream, true, {
-          nickname,
-        });
-      });
-    });
-
-    // 새로운 Offer 수신: 상대가 통화 요청
-    // 발생 시점: 새로운 사용자가 방에 입장했을 때, 기존 사용자가 createOffer를 호출하고 emit했을 때
-    socket.on(
-      "getOffer",
-      async (data: {
-        sdp: RTCSessionDescription;
-        offerSendID: string;
-        offerSendNickname: string;
-      }) => {
-        // 연결 생성
-        const pc = createPeerConnection(
-          data.offerSendID,
-          data.offerSendNickname,
-          stream,
-          false,
-          { nickname }
-        );
-        if (!pc) return;
-
-        try {
-          // 상대의 설정 확인하기: 상대의 미디어 형식, 코덱, 해상도 확인
-          await pc.setRemoteDescription(new RTCSessionDescription(data.sdp));
-          // Answer 생성: 수락 응답 만들기 - 내 미디어 설정 정보 생성, 상대 설정과 호환되는 형태로 생성
-          const answer = await pc.createAnswer();
-          // 로컬 설명 설정: 생성한 Answer 정보를 내 연결에 적용, 실제 통신 준비
-          await pc.setLocalDescription(answer);
-
-          // Answer 전송: 생성한 Answer를 상대에게 전송, 실제 연결 수립 시작
-          // emit: 서버로 이벤트 전송
-          socket.emit("answer", {
-            answerReceiveID: data.offerSendID,
-            sdp: answer,
-            answerSendID: socket.id,
-          });
-        } catch (error) {
-          console.error("Error handling offer:", error);
-        }
-      }
-    );
-
-    // Answer 수신: 상대방이 보낸 응답 수신, 연결 정보 설정, 실제 통신 준비 완료
-    socket.on(
-      "getAnswer",
-      async (data: { sdp: RTCSessionDescription; answerSendID: string }) => {
-        // 상대방과의 연결 정보 찾기
-        const pc = peerConnections.current[data.answerSendID];
-        if (!pc) return;
-        try {
-          // 상대방의 연결 정보 설정
-          await pc.setRemoteDescription(new RTCSessionDescription(data.sdp));
-        } catch (error) {
-          console.error("Error handling answer:", error);
-        }
-      }
-    );
-
-    // ICE candidate 수신: 새로운 연결 경로 정보 수신, 가능한 연결 경로 목록에 추가, 최적의 경로로 자동 전환
-    socket.on(
-      "getCandidate",
-      async (data: { candidate: RTCIceCandidate; candidateSendID: string }) => {
-        // 상대방과의 연결 찾기
-        const pc = peerConnections.current[data.candidateSendID];
-        if (!pc) return;
-        try {
-          // 새로운 연결 경로 추가
-          await pc.addIceCandidate(new RTCIceCandidate(data.candidate));
-        } catch (error) {
-          console.error("Error handling ICE candidate:", error);
-        }
-      }
-    );
-
-    // 사용자 퇴장 처리
-    socket.on("user_exit", ({ id }: { id: string }) => {
-      closePeerConnection(id);
-    });
-
-    socket.on(
-      "reaction",
-      ({ senderId, reaction }: { senderId: string; reaction: string }) => {
-        if (reactionTimeouts.current[senderId]) {
-          clearTimeout(reactionTimeouts.current[senderId]);
-        }
-
-        if (senderId === socket!.id) {
-          setReaction(reaction);
-          reactionTimeouts.current[senderId] = setTimeout(() => {
-            setReaction("");
-            delete reactionTimeouts.current[senderId];
-          }, 3000);
-        } else {
-          addReaction(senderId, reaction);
-          reactionTimeouts.current[senderId] = setTimeout(() => {
-            addReaction(senderId, "");
-            delete reactionTimeouts.current[senderId];
-          }, 3000);
-        }
-      }
-    );
+    console.log("Joining room:", sessionId);
+    socket.emit("join_room", { roomId: sessionId, nickname });
   };
 
-  const addReaction = useCallback((senderId: string, reactionType: string) => {
-    setPeers((prev) =>
-      prev.map((peer) =>
-        peer.peerId === senderId ? { ...peer, reaction: reactionType } : peer
-      )
-    );
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  const addReaction = useCallback(
+    (senderId: string, reactionType: string) => {
+      setPeers((prev) =>
+        prev.map((peer) =>
+          peer.peerId === senderId ? { ...peer, reaction: reactionType } : peer
+        )
+      );
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <section className="w-screen h-screen flex flex-col max-w-[1440px]">
       <div className="w-screen flex gap-2 mb-4 space-y-2 ">
-        <input
-          type="text"
-          placeholder="Room ID"
-          value={roomId}
-          onChange={(e) => setRoomId(e.target.value)}
-          className="border p-2 mr-2"
-        />
         <input
           type="text"
           placeholder="Nickname"
@@ -310,7 +304,6 @@ const SessionPage = () => {
             <div className={"listeners w-full flex gap-2 px-6"}>
               {useMemo(
                 () =>
-                  // 상대방의 비디오 표시
                   peers.map((peer) => (
                     <VideoContainer
                       key={peer.peerId}
@@ -342,7 +335,7 @@ const SessionPage = () => {
           socket={socket}
           question={"Restful API에 대해서 설명해주세요."}
           participants={[nickname, ...peers.map((peer) => peer.peerNickname)]}
-          roomId={roomId}
+          roomId={sessionId}
         />
       </div>
     </section>

--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -7,6 +7,7 @@ import useMediaDevices from "@/hooks/useMediaDevices.ts";
 import useToast from "@/hooks/useToast.ts";
 import usePeerConnection from "@/hooks/usePeerConnection.ts";
 import useSocketStore from "@/stores/useSocketStore";
+import useSessionFormStore from "@/stores/useSessionFormStore";
 
 interface User {
   id: string;
@@ -15,6 +16,7 @@ interface User {
 
 const SessionPage = () => {
   const { socket, connect } = useSocketStore();
+  const { sessionName } = useSessionFormStore();
 
   const {
     createPeerConnection,
@@ -293,7 +295,7 @@ const SessionPage = () => {
                 "text-center text-medium-xl font-bold w-full pt-4 pb-2"
               }
             >
-              프론트엔드 초보자 면접 스터디
+              {sessionName}
             </h1>
             <div className={"speaker max-w-4xl px-6 flex w-full"}>
               <VideoContainer

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,17 +1,17 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import removeConsole from "vite-plugin-remove-console";
-import { resolve } from 'path'
+import { resolve } from "path";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), removeConsole()],
   resolve: {
     alias: {
-      '@': resolve(__dirname, 'src'),
-      '@components': resolve(__dirname, 'src/components'),
-      '@hooks': resolve(__dirname, 'src/hooks'),
-      '@stores': resolve(__dirname, 'src/stores'),
-    }
-  }
+      "@": resolve(__dirname, "src"),
+      "@components": resolve(__dirname, "src/components"),
+      "@hooks": resolve(__dirname, "src/hooks"),
+      "@stores": resolve(__dirname, "src/stores"),
+    },
+  },
 });


### PR DESCRIPTION
## 관련 이슈 번호
> - 작성자: 이승윤
> - 작성 날짜: 2024.11.14

- #101 
  - #105 

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- 백엔드 서버와 연결해서 방 생성 확인
- 만들어진 방 링크로 다른 사용자 접속
- 백엔드 데이터 형식으로 인한 코드 수정

## 📝 작업 상세 내역
### 세션 생성 후 입장

<img width="1115" alt="스크린샷 2024-11-14 오후 7 59 27" src="https://github.com/user-attachments/assets/ce3c3b35-ff57-4a02-9c1a-ca6e46200203">

- 세션 만들기에서 create_room으로 서버에 요청하면 서버가 roomId를 주고, 해당 roomId를 이용해 접속한다.
- 상대방도 session/:sessionId를 같이 입력하고 닉네임을 입력하면 같은 방에 접속할 수 있다.
- 기존의 roomId 입력 부분이 이제 필요없어져서 지웠다.
- 입장하면 사용자가 입력한 이름으로 뜨는데, 링크로 들어온 상대는 방 이름을 볼 수가 없다.
  - 추후 서버에서 만들어진 방 title도 받아와서 넣는게 필요해보인다.
- 백엔드에서 배열로 소켓 아이디만을 전달해서 화상회의 기능이 동작하지 않았으나, 데이터 형식을 수정해서 그 부분에 맞게 수정한 후 오류가 해결되었다.

## 💬 다음 작업 또는 논의 사항
- 급하게 작업하느라 코드를 한 번 더 확인할 필요가 있을거 같음