### PR TITLE
[Feat] 사이드바 공용 컴포넌트 구현

### DIFF
--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -46,7 +46,9 @@ const Sidebar = () => {
     >
       <div>
         <header
-          className={"text-green-400 text-5xl text-center py-7 font-bold"}
+          className={
+            "text-green-400 text-5xl text-center py-7 font-bold hover:tracking-widest transition-all duration-700"
+          }
         >
           Preview
         </header>

--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -22,7 +22,7 @@ const Sidebar = () => {
       icon: <FaLayerGroup />,
     },
     {
-      path: "/mypage",
+      path: "/login",
       label: "마이페이지",
       icon: <FaRegCircleUser />,
     },

--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -94,14 +94,14 @@ const SidebarMenu = ({
 }: SidebarMenuProps) => {
   const activeClass = isSelected
     ? "bg-green-100 text-white"
-    : "bg-transparent ";
+    : "bg-transparent transition-color duration-300 hover:bg-gray-200/30";
 
   return (
     <li
-      className={`${activeClass} flex-nowrap text-nowrap text-bold-r px-4 p-2 w-full rounded-lg`}
+      className={`${activeClass} flex-nowrap text-nowrap text-bold-r px-4 p-2 w-full rounded-lg  `}
     >
       <Link
-        className={"inline-flex gap-2 items-center"}
+        className={"inline-flex gap-2 items-center w-full"}
         to={path}
         aria-label={label + "(으)로 이동하는 버튼"}
       >

--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -58,7 +58,10 @@ const Sidebar = () => {
           Preview
         </header>
         <hr className={"mx-6"} />
-        <ul className={"flex flex-col gap-1.5 items-center mx-4 p-2"}>
+        <ul
+          className={"flex flex-col gap-1.5 items-center mx-4 p-2"}
+          aria-label={"사이드바 링크 리스트"}
+        >
           {routes.map((route) => {
             return (
               <SidebarMenu
@@ -106,12 +109,9 @@ const SidebarMenu = ({
   return (
     <li
       className={`${activeClass} flex-nowrap text-nowrap text-bold-r px-4 p-2 w-full rounded-lg cursor-pointer`}
+      aria-label={label + "(으)로 이동하는 버튼"}
     >
-      <Link
-        className={"inline-flex gap-2 items-center w-full"}
-        to={path}
-        aria-label={label + "(으)로 이동하는 버튼"}
-      >
+      <Link className={"inline-flex gap-2 items-center w-full"} to={path}>
         {icon}
         <span>{label}</span>
       </Link>

--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -1,0 +1,113 @@
+import { Link } from "react-router-dom";
+import { ReactElement, useEffect, useState } from "react";
+import { FaClipboardList, FaHome, FaLayerGroup } from "react-icons/fa";
+import { MdLogout } from "react-icons/md";
+import { FaRegCircleUser } from "react-icons/fa6";
+
+const Sidebar = () => {
+  const routes = [
+    {
+      path: "/",
+      label: "홈",
+      icon: <FaHome />,
+    },
+    {
+      path: "/questions",
+      label: "질문지 리스트",
+      icon: <FaClipboardList />,
+    },
+    {
+      path: "/sessions",
+      label: "스터디 세션 목록",
+      icon: <FaLayerGroup />,
+    },
+    {
+      path: "/mypage",
+      label: "마이페이지",
+      icon: <FaRegCircleUser />,
+    },
+    {
+      path: "/logout",
+      label: "로그아웃",
+      icon: <MdLogout />,
+    },
+  ];
+
+  const [selected, setSelected] = useState<string>("");
+
+  useEffect(() => {
+    setSelected(window.location.pathname);
+  }, []);
+  return (
+    <nav
+      className={
+        "min-w-80 w-80 h-screen flex flex-col border-r gap-1.5 justify-between overflow-y-hidden"
+      }
+    >
+      <div>
+        <header
+          className={"text-green-400 text-5xl text-center py-7 font-bold"}
+        >
+          Preview
+        </header>
+        <hr className={"mx-6"} />
+        <ul className={"flex flex-col gap-1.5 items-center mx-4 p-2"}>
+          {routes.map((route) => {
+            return (
+              <SidebarMenu
+                key={route.path}
+                path={route.path}
+                label={route.label}
+                icon={route.icon}
+                isSelected={selected === route.path}
+              />
+            );
+          })}
+        </ul>
+      </div>
+      <a
+        className={"pb-4 px-6 text-medium-m hover:text-gray-500"}
+        href={"https://github.com/boostcampwm-2024/web27-Preview"}
+        aria-label={"리포지토리 링크"}
+        target={"_blank"}
+      >
+        <span>BOOSKIT</span>
+      </a>
+    </nav>
+  );
+};
+
+interface SidebarMenuProps {
+  path: string;
+  label: string;
+  icon?: ReactElement;
+  isSelected?: boolean;
+}
+
+const SidebarMenu = ({
+  path,
+  label,
+  icon,
+  isSelected = false,
+}: SidebarMenuProps) => {
+  const activeClass = isSelected
+    ? "bg-green-100 text-white"
+    : "bg-transparent ";
+
+  return (
+    <li
+      className={`${activeClass} flex-nowrap text-nowrap text-bold-r px-4 p-2 w-full rounded-lg`}
+    >
+      <Link
+        className={"inline-flex gap-2 items-center"}
+        to={path}
+        aria-label={label + "(으)로 이동하는 버튼"}
+      >
+        {icon}
+        <span>{label}</span>
+      </Link>
+    </li>
+  );
+};
+
+export default Sidebar;

--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -1,6 +1,11 @@
 import { Link } from "react-router-dom";
 import { ReactElement, useEffect, useState } from "react";
-import { FaClipboardList, FaHome, FaLayerGroup } from "react-icons/fa";
+import {
+  FaClipboardList,
+  FaExternalLinkAlt,
+  FaHome,
+  FaLayerGroup,
+} from "react-icons/fa";
 import { MdLogout } from "react-icons/md";
 import { FaRegCircleUser } from "react-icons/fa6";
 
@@ -73,7 +78,9 @@ const Sidebar = () => {
         aria-label={"리포지토리 링크"}
         target={"_blank"}
       >
-        <span>BOOSKIT</span>
+        <span className={"inline-flex items-center gap-1"}>
+          BOOSKIT <FaExternalLinkAlt size={12} />
+        </span>
       </a>
     </nav>
   );
@@ -98,7 +105,7 @@ const SidebarMenu = ({
 
   return (
     <li
-      className={`${activeClass} flex-nowrap text-nowrap text-bold-r px-4 p-2 w-full rounded-lg  `}
+      className={`${activeClass} flex-nowrap text-nowrap text-bold-r px-4 p-2 w-full rounded-lg cursor-pointer`}
     >
       <Link
         className={"inline-flex gap-2 items-center w-full"}

--- a/frontend/src/pages/SessionListPage.tsx
+++ b/frontend/src/pages/SessionListPage.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { IoMdAdd } from "react-icons/io";
 import SearchBar from "@/components/common/SearchBar.tsx";
 import useToast from "@/hooks/useToast";
+import Sidebar from "@components/common/Sidebar.tsx";
 
 interface Session {
   id: number;
@@ -84,65 +85,68 @@ const SessionListPage = () => {
   };
 
   return (
-    <section className={"flex flex-col gap-8 max-w-7xl w-screen h-screen p-20"}>
-      <div>
-        <h1 className={"text-bold-l mb-6"}>스터디 세션 목록</h1>
-        <div className={"h-11 flex gap-2 w-[47.5rem]"}>
-          <SearchBar text="세션을 검색하세요" />
-          <div className="relative inline-block items-center">
-            <select
+    <section className={"flex w-screen h-screen "}>
+      <Sidebar />
+      <div className={"flex flex-col gap-8 max-w-7xl p-20"}>
+        <div>
+          <h1 className={"text-bold-l mb-6"}>스터디 세션 목록</h1>
+          <div className={"h-11 flex gap-2 w-[47.5rem]"}>
+            <SearchBar text="세션을 검색하세요" />
+            <div className="relative inline-block items-center">
+              <select
+                className={
+                  "rounded-custom-m bg-green-200 text-semibold-s text-gray-white appearance-none pl-5 pr-11 h-full"
+                }
+              >
+                <option>FE</option>
+                <option>BE</option>
+              </select>
+              <span className="absolute top-1/2 -translate-y-1/2 right-3 pointer-events-none">
+                <IoChevronDownSharp className="w-5 h-5 text-gray-white" />
+              </span>
+            </div>
+            <button
               className={
-                "rounded-custom-m bg-green-200 text-semibold-s text-gray-white appearance-none pl-5 pr-11 h-full"
+                "flex justify-center items-center fill-current min-w-11 min-h-11 bg-green-200 rounded-custom-m box-border"
               }
+              onClick={() => navigate("/sessions/create")}
             >
-              <option>FE</option>
-              <option>BE</option>
-            </select>
-            <span className="absolute top-1/2 -translate-y-1/2 right-3 pointer-events-none">
-              <IoChevronDownSharp className="w-5 h-5 text-gray-white" />
-            </span>
+              <IoMdAdd className="w-[1.35rem] h-[1.35rem] text-gray-white" />
+            </button>
           </div>
-          <button
-            className={
-              "flex justify-center items-center fill-current min-w-11 min-h-11 bg-green-200 rounded-custom-m box-border"
-            }
-            onClick={() => navigate("/sessions/create")}
-          >
-            <IoMdAdd className="w-[1.35rem] h-[1.35rem] text-gray-white" />
-          </button>
         </div>
-      </div>
-      <div>
-        <h2 className={"text-semibold-l mb-6"}>공개된 세션 목록</h2>
-        <ul>
-          {listLoading ? (
-            <>loading</>
-          ) : (
-            <>
-              {sessionList.length <= 0 ? (
-                <li>아직 아무도 세션을 열지 않았어요..!</li>
-              ) : (
-                renderSessionList(SessionStatus.OPEN)
-              )}
-            </>
-          )}
-        </ul>
-      </div>
-      <div>
-        <h2 className={"text-semibold-l mb-6"}>진행 중인 세션 목록</h2>
-        <ul>
-          {listLoading ? (
-            <>loading</>
-          ) : (
-            <>
-              {sessionList.length <= 0 ? (
-                <li>아직 아무도 세션을 열지 않았어요..!</li>
-              ) : (
-                renderSessionList(SessionStatus.CLOSE)
-              )}
-            </>
-          )}
-        </ul>
+        <div>
+          <h2 className={"text-semibold-l mb-6"}>공개된 세션 목록</h2>
+          <ul>
+            {listLoading ? (
+              <>loading</>
+            ) : (
+              <>
+                {sessionList.length <= 0 ? (
+                  <li>아직 아무도 세션을 열지 않았어요..!</li>
+                ) : (
+                  renderSessionList(SessionStatus.OPEN)
+                )}
+              </>
+            )}
+          </ul>
+        </div>
+        <div>
+          <h2 className={"text-semibold-l mb-6"}>진행 중인 세션 목록</h2>
+          <ul>
+            {listLoading ? (
+              <>loading</>
+            ) : (
+              <>
+                {sessionList.length <= 0 ? (
+                  <li>아직 아무도 세션을 열지 않았어요..!</li>
+                ) : (
+                  renderSessionList(SessionStatus.CLOSE)
+                )}
+              </>
+            )}
+          </ul>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
> [!NOTE]
> 작성자: 서정우
> 작성 날짜: 2024.11.19

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

![image](https://github.com/user-attachments/assets/16b3341b-7886-41f2-9eff-91d60e20bb91)


## 🧩 작업 내용
- 사이드바 공용 컴포넌트 구현

## 📝 작업 상세 내역
### 사이드바 UI 구현
- 피그마에 디자인한 사이드바를 그대로 구현
- 애니메이션, 접근성 라벨 등 추가
- 사이드바 아래에 Preview 리포지토리로 이동하는 링크 추가
- 각 사이드바 메뉴 클릭시 해당하는 route로 이동하도록 구현


## 📌 테스트 및 검증 결과
![사이드바 구현](https://github.com/user-attachments/assets/419faec6-3b41-408b-a098-41fb5c9349cf)


## 💬 다음 작업 또는 논의 사항
- 사이드바를 추가해야 할 페이지를 선별하면 좋을 것 같습니다.
