### PR TITLE
[Refactor] Toast 메시지 리팩토링

### DIFF
--- a/frontend/src/components/common/Toast.tsx
+++ b/frontend/src/components/common/Toast.tsx
@@ -11,14 +11,19 @@ const Toast = ({ message, type, removeToast }: ToastProps) => {
   return (
     <div
       className={`relative flex items-center text-medium-s ${type === "error" ? "bg-red-400" : "bg-green-100"} overflow-hidden text-white w-80 h-16 shadow-xl  p-2 z-50 revealExpand`}
+      aria-label={`${type}타입의 토스트 메시지, 5초 후에 사라집니다.`}
     >
       <div className={"flex"}>
-        <p className={"flex-grow break-keep whitespace-pre-wrap hyphens-none"}>
+        <p
+          className={"flex-grow break-keep whitespace-pre-wrap hyphens-none"}
+          aria-label={"토스트 메시지 내용"}
+        >
           {message}
         </p>
         <button
           onClick={removeToast}
           className={"text-2xl absolute right-1 top-1"}
+          aria-label={"토스트 메시지 닫기 버튼"}
         >
           <IoIosClose />
         </button>

--- a/frontend/src/components/common/ToastProvider.tsx
+++ b/frontend/src/components/common/ToastProvider.tsx
@@ -11,7 +11,7 @@ const ToastProvider = () => {
   const { toasts, removeToast } = useToastStore();
 
   return (
-    <div className={"absolute z-50 flex flex-col gap-2 top-10 right-10"}>
+    <div className={"fixed z-50 flex flex-col gap-2 top-10 right-10"}>
       {toasts.map((toast: Toast) => {
         return (
           <Toast

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -8,7 +8,7 @@ const useToast = () => {
   const toast = useCallback(
     (message: string, type: "success" | "error") => {
       const newToast = {
-        id: new Date().getTime(),
+        id: new Date().getTime() + Math.floor(Math.random() * 200),
         message,
         type,
         duration: DURATION || 5000,

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -1,9 +1,10 @@
 import useToastStore from "@/stores/useToastStore";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 const useToast = () => {
   const { createToast, removeToast } = useToastStore();
   const DURATION = 5000;
+  const timerIDs = useRef<ReturnType<typeof setTimeout>[]>([]);
 
   const toast = useCallback(
     (message: string, type: "success" | "error") => {
@@ -15,10 +16,20 @@ const useToast = () => {
       };
 
       createToast(newToast);
-      setTimeout(() => removeToast(newToast.id), DURATION);
+      const id = setTimeout(() => {
+        removeToast(newToast.id);
+        timerIDs.current = timerIDs.current.filter((timerId) => timerId !== id);
+      }, DURATION);
+      timerIDs.current.push(id);
     },
     [createToast, removeToast]
   );
+
+  useEffect(() => {
+    return () => {
+      timerIDs.current.forEach((id) => clearTimeout(id));
+    };
+  }, []);
 
   const success = useCallback(
     (message: string) => {

--- a/frontend/src/stores/useToastStore.ts
+++ b/frontend/src/stores/useToastStore.ts
@@ -17,7 +17,7 @@ const useToastStore = create<ToastState>((set) => ({
   toasts: [] as Toast[],
   // 액션
   createToast: (toast: Toast) =>
-    set((state) => ({ toasts: [...state.toasts, toast] })),
+    set((state) => ({ toasts: [toast, ...state.toasts] })),
   removeToast: (id: number) =>
     set((state) => ({
       toasts: state.toasts.filter((toast: Toast) => toast.id !== id),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2541,7 +2541,14 @@ packages:
   hexoid@2.0.0:
     resolution: {integrity: sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==}
     engines: {node: '>=8'}
-    
+
+  howler@2.2.4:
+    resolution: {integrity: sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w==}
+
+  html-encoding-sniffer@3.0.0:
+    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
+    engines: {node: '>=12'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -3468,6 +3475,9 @@ packages:
     peerDependencies:
       react: '*'
 
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
@@ -3514,6 +3524,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
     engines: {node: '>=4'}
@@ -3524,6 +3538,9 @@ packages:
 
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
+  regenerator-runtime@0.11.1:
+    resolution: {integrity: sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==}
 
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
@@ -6971,12 +6988,12 @@ snapshots:
 
   hexoid@2.0.0: {}
 
+  howler@2.2.4: {}
+
   html-encoding-sniffer@3.0.0:
     dependencies:
       whatwg-encoding: 2.0.0
 
-  howler@2.2.4: {}
-  
   html-escaper@2.0.2: {}
 
   http-errors@2.0.0:
@@ -8045,6 +8062,8 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  react-is@16.13.1: {}
+
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
@@ -8098,6 +8117,11 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   redis-errors@1.2.0: {}
 
   redis-parser@3.0.0:
@@ -8105,6 +8129,8 @@ snapshots:
       redis-errors: 1.2.0
 
   reflect-metadata@0.2.2: {}
+
+  regenerator-runtime@0.11.1: {}
 
   regenerator-runtime@0.14.1: {}
 


### PR DESCRIPTION
> [!NOTE]
> 토스트메시지를 리팩토링했습니다. 원래 고유아이디 문제를 해결하려고 했는데 하는 겸사겸사 토스트 스택 순서 방향도 변경했습니다. 

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- 토스트 메시지 개선
- <ToastProvider/> 에서 렌더링하는 순서를 반대로 변경해서 자연스러운 애니메이션 유도
- 고유 ID에 랜덤한 값을 더하는 방식으로 중복확률 줄이기


## 고유 ID
- 현재는 생성된 시간을 ID로 사용하고 있다.
- 생성된 시간이 같다면? 실제로 소켓 이벤트 같은 경우 동시에 여러번 발생될 확률이 있고 실제 테스트 중에서도 여러 토스트 메시지가 동시에 발생한 적이 있었다.
- 그럴 때 5초 뒤 삭제되지 않고 남아있는 문제가 발생했었다. (같은 ID 토스트가 2개라면 1개만 사라지고 1개는 남는다)
- id + random 수 (0~200) 으로 하기로 결정
- 완전 고유한 아이디를 생성하기 위해 uuid 같은 라이브러리를 쓸 수도 있지만 라이브러리를 굳이 쓰고 싶지 않았다.

## 토스트 메시지 스택 순서

기존에는 새로 생긴 토스트 메시지를 아래에 추가하는 방식이었다.

아래에 추가하는 방식을 사용하니 문제점은 가장 위에 있는 토스트메시지가 먼저 사라지는 점이었다. 위 메시지가 사라지면 아래 메시지가 올라오는데, 이 부분이 뭔가 부자연스럽게 느껴졌다.

###### 순서 변경 전
![토스트 개선 전](https://github.com/user-attachments/assets/6b4236e3-fccf-4138-b892-18b18969a1e9)

###### 순서 변경 후
![토스트 개선 후](https://github.com/user-attachments/assets/63f5f777-31c3-47ba-aa8d-637222f58c15)

```tsx
 // ToastProvider에서 반대로 렌더링해줄 수도 있지만 그 경우 reverse 하는 코스트가 든다.
 // 새로운 토스트를 맨 앞에 추가해주는 방식으로 변경했다.
 createToast: (toast: Toast) =>
    set((state) => ({ toasts: [toast, ...state.toasts] })),
```

## 화면 스크롤시 토스트의 위치

화면 스크롤시 토스트 메시지가 화면에서 안보이는 문제가 있었다. 스크롤을 생각하지 못하고 구현했던게 문제였다. 간단하게 Provider에 `position: fixed` 를 적용하여 해결했다.

###### 개선 전
![스크롤 문제](https://github.com/user-attachments/assets/11178d8c-37dd-443e-b90e-51d933a5c4b7)


###### 개선 후
![스크롤 문제 해결](https://github.com/user-attachments/assets/8cfc371f-74e5-4b18-bdb2-ca02581b43a1)

## 최대 표시 개수 제한?

- 필요할까?
    - 굳이 제한할 필요는 없을 것 같다.
- 10개가 넘는 토스트메시지도 잘 작동하는 것을 볼 수 있다.

![image.png](https://prod-files-secure.s3.us-west-2.amazonaws.com/e1ec33c1-2b69-4aa8-88fc-22a0d17eaa63/61c4c8a8-0537-48ff-9cb6-e7d49cbe2d99/image.png)

### 메모리 누수 방지

setTimeout 클린업을 해야하는 이유에 대해서 궁금해졌다. setTimeout 이 끝나면 자동으로 처리되는거 아닌가? 하는 생각 때문에 찾아보기로 했다.

#### 메모리 누수 방지

일단 메모리 누수를 방지하기 위한 목적으로 `클린업 함수`를 구현한다는 것은 알고 있었다. 하지만 어떻게 해서 누수가 방지된다는 것인지 명확하게 알게 되었다.

`setTimeout`을 호출하면 타이머가 생기고, 해당 타이머로 인해 실행될 콜백함수가 무조건 제시간에 실행된다는 보장이 있다면 클린업 함수를 구현할 필요가 없다고 한다.

즉, 코드가 복잡해지고 브라우저의 메모리를 많이 사용하고 있다면 브라우저의 동작이 느려지고 예기치 못한 동작이 생길 수 있다. 이럴 때 `콜백함수`가 제때 실행되지 않고 남아있는 경우가 생길 수 있다.

남아있는 `타이머`는 다음 리렌더링 이후에 **원치 않는 토스트 메시지를 삭제하려고 시도**할 수 있다. 그래서 **클린업함수로 컴포넌트 언마운트시 타이머들을 제거**해줘야한다.

```tsx
const timerIDs = useRef<ReturnType<typeof setTimeout>[]>([]);
const toast = useCallback(
  (message: string, type: "success" | "error") => {
    const newToast = {
      id: new Date().getTime() + Math.floor(Math.random() * 200),
      message,
      type,
      duration: DURATION || 5000,
    };

    createToast(newToast);
    const id = setTimeout(() => {
      removeToast(newToast.id);
      timerIDs.current = timerIDs.current.filter((timerId) => timerId !== id);
    }, DURATION);
    timerIDs.current.push(id);
  },
  [createToast, removeToast]
);
```