### PR TITLE
[Design] 일부 페이지 디자인 통일 

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@dotlottie/react-player": "^1.6.19",
+    "@tanstack/react-query": "^5.60.6",
+    "@tanstack/react-query-devtools": "^5.60.6",
     "@types/react-lottie": "^1.2.10",
     "@types/socket.io-client": "^3.0.0",
     "react": "^18.3.1",

--- a/frontend/src/components/common/SearchBar.tsx
+++ b/frontend/src/components/common/SearchBar.tsx
@@ -9,7 +9,7 @@ const SearchBar = ({ text }: Props) => {
       <IoIosSearch className="absolute left-4 w-5 h-5" />
       <input
         className={
-          "rounded-custom-m pl-10 px-4 w-full h-full border border-gray-200 text-medium-r"
+          "rounded-custom-m pl-10 px-4 w-full h-full border border-gray-200 text-medium-m"
         }
         type="text"
         placeholder={text}

--- a/frontend/src/components/common/Select.tsx
+++ b/frontend/src/components/common/Select.tsx
@@ -14,7 +14,7 @@ const Select = ({ options, backgroundColor = "bg-green-200" }: SelectProps) => {
   return (
     <div className="relative inline-block items-center">
       <select
-        className={`rounded-custom-m ${backgroundColor} text-semibold-s text-gray-white appearance-none pl-5 pr-11 h-full`}
+        className={`rounded-custom-m ${backgroundColor} text-semibold-r text-gray-white appearance-none pl-5 pr-11 h-full`}
       >
         {options.map((option) => (
           <option key={option.value}>{option.label}</option>

--- a/frontend/src/components/common/Sidebar.tsx
+++ b/frontend/src/components/common/Sidebar.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import { ReactElement, useEffect, useState } from "react";
 import { FaClipboardList, FaHome, FaLayerGroup } from "react-icons/fa";
 import { MdDarkMode, MdLightMode, MdLogout } from "react-icons/md";
-import { FaRegCircleUser } from "react-icons/fa6";
+import { IoPersonSharp } from "react-icons/io5";
 import { FaGithub } from "react-icons/fa6";
 import useTheme from "@hooks/useTheme.ts";
 const Sidebar = () => {
@@ -25,7 +25,7 @@ const Sidebar = () => {
     {
       path: "/login",
       label: "마이페이지",
-      icon: <FaRegCircleUser />,
+      icon: <IoPersonSharp />,
     },
     {
       path: "/logout",
@@ -43,7 +43,7 @@ const Sidebar = () => {
   return (
     <nav
       className={
-        "min-w-80 w-80 h-screen flex flex-col border-r gap-1.5 justify-between overflow-y-hidden bg-white transition-colors dark:bg-gray-black dark:border-r-gray-400"
+        "min-w-17.5 w-17.5 h-screen flex flex-col border-r-custom-s gap-1.5 justify-between overflow-y-hidden bg-white transition-colors dark:bg-gray-black dark:border-r-gray-400"
       }
     >
       <div>
@@ -54,9 +54,9 @@ const Sidebar = () => {
         >
           Preview
         </header>
-        <hr className={"mx-6 dark:border-gray-400"} />
+        <hr className={"mx-4 dark:border-gray-400"} />
         <ul
-          className={"flex flex-col gap-1.5 items-center mx-4 p-2"}
+          className={"flex flex-col gap-2 items-center mx-2 my-2 p-2"}
           aria-label={"사이드바 링크 리스트"}
         >
           {routes.map((route) => {
@@ -114,15 +114,15 @@ const SidebarMenu = ({
   isSelected = false,
 }: SidebarMenuProps) => {
   const activeClass = isSelected
-    ? "bg-green-100 dark:text-black text-white"
-    : "bg-transparent dark:text-white text-black transition-color duration-300 hover:bg-gray-200/30";
+    ? "bg-green-100 dark:text-gray-black text-white text-semibold-m"
+    : "bg-transparent dark:text-white text-gray-black text-medium-l transition-color duration-300 hover:bg-gray-200/30";
 
   return (
     <li
-      className={`${activeClass} flex-nowrap text-nowrap text-bold-r px-4 p-2 w-full rounded-lg cursor-pointer`}
+      className={`${activeClass} flex items-center flex-nowrap text-nowrap px-4 p-2 w-full rounded-lg cursor-pointer`}
       aria-label={label + "(으)로 이동하는 버튼"}
     >
-      <Link className={"inline-flex gap-2 items-center w-full"} to={path}>
+      <Link className={"inline-flex gap-3 items-center w-full"} to={path}>
         {icon}
         <span>{label}</span>
       </Link>

--- a/frontend/src/components/questions/QuestionsPreviewCard.tsx
+++ b/frontend/src/components/questions/QuestionsPreviewCard.tsx
@@ -20,11 +20,11 @@ const QuestionCard = ({
 }: QuestionCardProps) => {
   return (
     <div
-      className="bg-white backdrop-blur-sm border border-gray-200 rounded-xl p-3 hover:bg-gray-200/70 transition-all cursor-pointer group dark:bg-gray-900/80 dark:border-gray-700 dark:hover:bg-gray-600/70"
+      className="bg-white backdrop-blur-sm border border-gray-200 rounded-xl p-4 hover:bg-gray-200/70 transition-all cursor-pointer group dark:bg-gray-900/80 dark:border-gray-700 dark:hover:bg-gray-600/70"
       onClick={onClick}
     >
-      <div className="flex justify-between items-start mb-4 pt-1">
-        <span className="px-3 py-0.5  bg-emerald-50 text-emerald-600 dark:bg-emerald-600/20 dark:text-emerald-400 text-sm rounded-full">
+      <div className="flex justify-between items-start mb-3 pt-1">
+        <span className="px-3 py-0.5 bg-emerald-50 text-emerald-600 dark:bg-emerald-600/20 dark:text-emerald-400 text-sm rounded-full">
           {category}
         </span>
         <FaStar
@@ -36,12 +36,12 @@ const QuestionCard = ({
         />
       </div>
 
-      <h3 className="text-lg font-semibold text-black dark:text-white mb-4 line-clamp-2">
+      <h3 className="text-lg font-semibold text-black dark:text-white pl-1 mb-4 line-clamp-2">
         {title}
       </h3>
 
       <div className="flex items-center justify-between text-sm text-gray-400 dark:text-gray-100">
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1 pl-1">
           <span>{questionCount}</span>
           <span>문항</span>
         </div>

--- a/frontend/src/components/sessions/SessionCard.tsx
+++ b/frontend/src/components/sessions/SessionCard.tsx
@@ -33,9 +33,9 @@ const SessionCard = ({
         >
           {category}
         </span>
-        <h3 className={"text-semibold-r mt-[0.5rem]"}>{title}</h3>
+        <h3 className={"text-semibold-m mt-[0.5rem]"}>{title}</h3>
         <p className={"text-medium-r text-gray-400"}>
-          질문지인데 누르면 질문 리스트를 볼 수 있임 {questionListId}
+          질문지인데 누르면 질문 리스트를 볼 수 있음 {questionListId}
         </p>
         <div
           className={
@@ -53,7 +53,7 @@ const SessionCard = ({
           {sessionStatus === "open" ? (
             <button
               className={
-                "text-semibold-s text-green-500 inline-flex items-center gap-[0.5rem] hover:gap-[0.375rem] transition-all"
+                "text-semibold-r text-green-500 inline-flex items-center gap-[0.5rem] hover:gap-[0.375rem] transition-all"
               }
               onClick={onEnter}
             >

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,12 +4,18 @@ import "./index.css";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { routes } from "./routes.tsx";
 import ToastProvider from "./components/common/ToastProvider.tsx";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 const router = createBrowserRouter(routes);
+const queryClient = new QueryClient();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ToastProvider />
-    <RouterProvider router={router} />
+    <QueryClientProvider client={queryClient}>
+      <ReactQueryDevtools initialIsOpen={false} />
+      <ToastProvider />
+      <RouterProvider router={router} />
+    </QueryClientProvider>
   </StrictMode>
 );

--- a/frontend/src/pages/ErrorPage.tsx
+++ b/frontend/src/pages/ErrorPage.tsx
@@ -35,7 +35,7 @@ const ErrorPage = () => {
           />
           <span
             className={
-              "text-9xl [text-shadow:_0_2px_2px_rgb(0_0_0_/_40%)] absolute right-80 top-1/2  font-bold"
+              "text-9xl [text-shadow:_0_2px_2px_rgb(0_0_0_/_40%)] absolute right-80 top-1/2 font-bold"
             }
           >
             4
@@ -43,15 +43,15 @@ const ErrorPage = () => {
         </div>
         <div
           className={
-            "absolute bottom-16 left-1/2 transform -translate-x-1/2 z-20 pointer-events-nones"
+            "absolute bottom-12 left-1/2 transform -translate-x-1/2 z-20 pointer-events-nones"
           }
         >
           <p className={"font-light text-xl"}>
-            이런! 요청하신 데이터를 찾을 수 없었어요!
+            이런! 요청하신 데이터를 찾을 수 없어요!
           </p>
           <button
             className={
-              " bg-green-500 hover:bg-green-600 text-white p-2 rounded-lg mt-4 "
+              "text-semibold-l text-green-500 hover:text-green-600 p-2 rounded-lg mt-4"
             }
             onClick={() => navigate("/sessions")}
           >

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -5,11 +5,11 @@ import mainSnowman from "../../public/assets/noondeumyum.lottie";
 
 const LoginPage = () => {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-900 to-gray-800 flex items-center justify-center p-8">
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800 flex items-center justify-center p-8">
       {/* 전체 컨테이너 */}
       <div className="w-full max-w-7xl mx-auto px-8">
         {/* 전체 콘텐츠를 감싸는 프레임 */}
-        <div className="h-[640px] bg-gray-800/50 backdrop-blur-md rounded-2xl border border-gray-700 shadow-xl overflow-hidden">
+        <div className="h-[640px] bg-gray-800/50 backdrop-blur-md rounded-2xl shadow-24 overflow-hidden">
           {/* 내부 콘텐츠 그리드 */}
           <div className="flex h-full">
             {/* 왼쪽 콘텐츠 영역 - 7칸 차지 */}
@@ -26,8 +26,8 @@ const LoginPage = () => {
             </div>
 
             {/* 오른쪽 로그인 폼 - 5칸 차지 */}
-            <div className="col-span-5 p-16 bg-gray-50 w-full lg:w-5/12">
-              <h1 className="text-7xl font-pretendard font-bold black mb-8 tracking-tight text-center">
+            <div className="col-span-5 p-16 bg-gray-white w-full lg:w-5/12">
+              <h1 className="text-6xl font-raleway font-bold black mb-11 tracking-tight text-center">
                 Preview
               </h1>
               <div className="w-full max-w-md mx-auto">
@@ -52,7 +52,7 @@ const LoginPage = () => {
 
                   <button
                     type="submit"
-                    className="w-full bg-emerald-600 text-white py-3 rounded-md hover:bg-emerald-500 transition-colors font-medium text-lg shadow-lg"
+                    className="w-full bg-green-200 text-white py-3 rounded-md hover:bg-green-100 transition-colors font-medium text-lg shadow-16"
                   >
                     로그인
                   </button>
@@ -60,13 +60,13 @@ const LoginPage = () => {
                   <div className="flex items-center justify-between text-base text-gray-600">
                     <button
                       type="button"
-                      className="hover:text-emerald-600 transition-colors"
+                      className="hover:text-green-300 transition-colors"
                     >
                       회원가입
                     </button>
                     <button
                       type="button"
-                      className="hover:text-emerald-600 transition-colors"
+                      className="hover:text-green-300 transition-colors"
                     >
                       비밀번호 찾기
                     </button>
@@ -85,14 +85,14 @@ const LoginPage = () => {
                   {/* OAuth 로그인 버튼 */}
                   <button
                     type="button"
-                    className="w-full bg-gray-900 text-white py-3 rounded-md hover:bg-gray-800 transition-colors font-medium text-lg shadow-lg flex items-center justify-center gap-3"
+                    className="w-full bg-gray-900 text-white py-3 rounded-md hover:bg-gray-800 transition-colors font-medium text-lg shadow-16 flex items-center justify-center gap-3"
                   >
                     <FaGithub className="w-5 h-5" />
                     GitHub으로 계속하기
                   </button>
                   <button
                     type="button"
-                    className="w-full bg-blue-500 text-white py-3 rounded-md hover:bg-blue-400 transition-colors font-medium text-lg shadow-lg flex items-center justify-center gap-3"
+                    className="w-full bg-blue-500 text-white py-3 rounded-md hover:bg-blue-400 transition-colors font-medium text-lg shadow-16 flex items-center justify-center gap-3"
                   >
                     <FaGoogle className="w-5 h-5" />
                     Google으로 그만하기

--- a/frontend/src/pages/QuestionListPage.tsx
+++ b/frontend/src/pages/QuestionListPage.tsx
@@ -1,4 +1,3 @@
-import { FaPlus } from "react-icons/fa6";
 import Sidebar from "@components/common/Sidebar.tsx";
 import SearchBar from "@components/common/SearchBar.tsx";
 import QuestionsPreviewCard from "@components/questions/QuestionsPreviewCard.tsx";
@@ -6,6 +5,8 @@ import Select from "@components/common/Select.tsx";
 import useToast from "@hooks/useToast.ts";
 import { useEffect, useState } from "react";
 import LoadingIndicator from "@components/common/LoadingIndicator.tsx";
+import { IoMdAdd } from "react-icons/io";
+import { useNavigate } from "react-router-dom";
 
 interface Question {
   id: number;
@@ -21,6 +22,7 @@ const QuestionList = () => {
   // 더미 데이터
   const [questionList, setQuestionList] = useState<Question[]>([]);
   const [questionLoading, setQuestionLoading] = useState(true);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const questionLists = [
@@ -86,14 +88,14 @@ const QuestionList = () => {
   };
 
   return (
-    <section className="flex w-screen min-h-screen ">
+    <section className="flex w-screen min-h-screen">
       <Sidebar />
-      <div className="max-w-7xl w-full mx-auto p-8">
+      <div className="max-w-7xl w-full px-12 pt-20">
         <div className="mb-12">
-          <h1 className="text-4xl font-bold text-black dark:text-white my-4">
+          <h1 className="text-bold-l text-gray-black dark:text-white mb-6">
             질문지 목록
           </h1>
-          <div className="flex gap-4 items-stretch justify-between">
+          <div className="flex gap-2 items-stretch justify-between">
             <SearchBar text={"질문지 검색하기"} />
             <Select
               options={[
@@ -102,13 +104,18 @@ const QuestionList = () => {
                 { label: "CS", value: "CS" },
               ]}
             />
-            <button className="flex items-center gap-2 px-4 py-3 bg-green-200 text-white rounded-lg hover:bg-emerald-500 transition-colors">
-              <FaPlus className="w-5 h-5" />
+            <button
+              className={
+                "flex justify-center items-center fill-current min-w-11 min-h-11 bg-green-200 rounded-custom-m box-border"
+              }
+              onClick={() => navigate("/questions/create")}
+            >
+              <IoMdAdd className="w-[1.35rem] h-[1.35rem] text-gray-white" />
             </button>
           </div>
         </div>
         <LoadingIndicator loadingState={questionLoading} />
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3  gap-6">
+        <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4">
           {questionList.map((list) => (
             <QuestionsPreviewCard
               key={list.id}

--- a/frontend/src/pages/SessionListPage.tsx
+++ b/frontend/src/pages/SessionListPage.tsx
@@ -85,9 +85,9 @@ const SessionListPage = () => {
   };
 
   return (
-    <section className={"flex w-screen h-screen "}>
+    <section className={"flex w-screen h-screen"}>
       <Sidebar />
-      <div className={"flex flex-col gap-8 max-w-7xl p-20"}>
+      <div className={"flex flex-col gap-8 max-w-7xl px-12 pt-20"}>
         <div>
           <h1 className={"text-bold-l mb-6"}>스터디 세션 목록</h1>
           <div className={"h-11 flex gap-2 w-[47.5rem]"}>
@@ -110,7 +110,7 @@ const SessionListPage = () => {
           </div>
         </div>
         <div>
-          <h2 className={"text-semibold-l mb-6"}>공개된 세션 목록</h2>
+          <h2 className={"text-semibold-l mb-4"}>공개된 세션 목록</h2>
           <ul>
             {listLoading ? (
               <>loading</>
@@ -126,7 +126,7 @@ const SessionListPage = () => {
           </ul>
         </div>
         <div>
-          <h2 className={"text-semibold-l mb-6"}>진행 중인 세션 목록</h2>
+          <h2 className={"text-semibold-l mb-4"}>진행 중인 세션 목록</h2>
           <ul>
             {listLoading ? (
               <>loading</>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -43,6 +43,7 @@ export default {
       boxShadow: {
         8: "0 0 0.2rem 0.125rem rgba(182, 182, 182, 0.08)",
         16: "0 0 0.125rem 0.075rem rgba(182, 182, 182, 0.16)",
+        24: "0 0 0.4rem 0.15rem rgba(182, 182, 182, 0.24)",
       },
       fontSize: {
         // Bold(700) sizes
@@ -52,19 +53,18 @@ export default {
         "bold-s": ["1.125rem", { lineHeight: "auto", fontWeight: "700" }],
 
         // SemiBold(600) sizes
-        "semibold-l": ["1.375rem", { lineHeight: "auto", fontWeight: "600" }],
-        "semibold-m": ["1.25rem", { lineHeight: "auto", fontWeight: "600" }],
-        "semibold-r": ["1.125rem", { lineHeight: "auto", fontWeight: "600" }],
-        "semibold-s": ["1rem", { lineHeight: "auto", fontWeight: "600" }],
+        "semibold-l": ["1.25rem", { lineHeight: "auto", fontWeight: "600" }],
+        "semibold-m": ["1.125rem", { lineHeight: "auto", fontWeight: "600" }],
+        "semibold-r": ["1rem", { lineHeight: "auto", fontWeight: "600" }],
+        "semibold-s": ["0.8rem", { lineHeight: "auto", fontWeight: "600" }],
 
         // Medium(500) sizes
-        "medium-xl": ["1.375rem", { lineHeight: "auto", fontWeight: "500" }],
-        "medium-l": ["1.25rem", { lineHeight: "auto", fontWeight: "500" }],
-        "medium-m": ["1.125rem", { lineHeight: "auto", fontWeight: "500" }],
-        "medium-r": ["1rem", { lineHeight: "auto", fontWeight: "500" }],
+        "medium-xl": ["1.25rem", { lineHeight: "auto", fontWeight: "500" }],
+        "medium-l": ["1.125rem", { lineHeight: "auto", fontWeight: "500" }],
+        "medium-m": ["1rem", { lineHeight: "auto", fontWeight: "500" }],
+        "medium-r": ["0.9rem", { lineHeight: "auto", fontWeight: "500" }],
         "medium-s": ["0.875rem", { lineHeight: "auto", fontWeight: "500" }],
         "medium-xs": ["0.75rem", { lineHeight: "auto", fontWeight: "500" }],
-        "medium-xxs": ["0.625rem", { lineHeight: "auto", fontWeight: "500" }],
       },
       fontFamily: {
         pretendard: ["Pretendard", "sans-serif"],
@@ -72,10 +72,11 @@ export default {
       },
       spacing: {
         0.375: "0.375rem",
+        17.5: "17.5rem",
         27.5: "27.5rem",
         42.5: "42.5rem",
         47.5: "47.5rem",
-      },
+      }, 
     },
   },
   plugins: [],


### PR DESCRIPTION
> [!NOTE]
> - 작성자: 이승윤
> - 작성 날짜: 2024.11.20

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- tanstack query 설치
- 페이지 별 디자인 일부 통일

## 📝 작업 상세 내역
### 페이지 별 일부 디자인 통일
<img width="1445" alt="스크린샷 2024-11-20 오후 7 59 37" src="https://github.com/user-attachments/assets/653ef844-b63d-406a-a075-11eef937926d">
<img width="1445" alt="스크린샷 2024-11-20 오후 7 59 41" src="https://github.com/user-attachments/assets/562555be-2e49-42d4-bfa5-eec5cdc7e7e1">

- 시간이 없어서 일부분만 수정했습니다.
  - 생각보다 제가 UI를 신경 많이 못 썼는데 마음에 걸려서 조금 수정했습니다.
  - 피그마 쓸 때는 몰랐는데 `폰트`가 많이 크다는 느낌을 받아서 줄였습니다. 줄여도 큰 편이긴 합니다. 😅
- 질문지 리스트 검색 바가 지나치게 길다는 느낌을 받았는데 어떤가요? 고민되네요.
  - 해당 부분 UI도 고민을 좀 해봐야할 거 같습니다.
  - 현재 제 화면이 커서 그렇긴한데, `노트북 사용자나 아이패드 사용자를 기준으로 width`를 정해두면 어떨까 싶습니다.
  - 면접 스터디 특성상 여러 사람과 화면을 보고 소통하다보니 `모바일 사용자`를 고려하기보다(모바일에서 면접 연습을 한다는게 자신의 영상, 상대 영상, 질문까지 다 볼 수 있어야하는데 연습하기엔 무리가 아닌가 하는 생각이 듭니다. 무엇보다 실제 면접 연습을 하는 공간인데 실제 면접을 휴대폰으로 보는 사람은 거의 없지 않을까?하는 생각이 들었습니다.)는 태블릿 크기부터 고려하는게 좋을거 같다는 생각이 듭니다.
  - 지금 스터디 세션 목록 페이지가 사이드바 제외하고 760px 정도 쯤 되는걸로 아는데 사이드바까지 하면 1000px이 넘습니다. 그럼 일반 노트북을 꽉채우게 될거 같은데, 이 정도로 너비를 정해두는거 어떨까요?
  ![스크린샷 2024-11-20 오후 8 17 10](https://github.com/user-attachments/assets/df73332b-19e7-421d-8f00-4bb1eda938e7)
  - 이런식으로 모니터 같은데서는 오른쪽 여백이 생기는거도 괜찮을거 같습니다. (사이드 바가 왼쪽에 위치하기 때문에 오른쪽 여백이 있는게 자연스러울거 같습니다.)
- 사이드 바가 생각보다 넓은 거 같아 살짝 줄였습니다. 사이드 바가 너무 두꺼우면 답답할거 같아서 적당히 줄여보았습니다.

## 💬 다음 작업 또는 논의 사항
- pages에 있는 코드와 같이 코드가 생각보다 많이 긴 코드들이 많았습니다. 적당한 길이로 분리를 해야할거 같습니다.
  - 시간 날 때마다 분리를 해두는게 좋을거 같습니다. 나중에 리팩토링 시간이 있어도 제가 코드를 살펴보니 분리할 부분이 많아 보여서 시간 날 때 조금씩 적당히라도 분리해두면 좋을거 같습니다.
- tanstack query를 설치해서 서버와 연결을 할 때 사용할 거 같습니다.
- tailwind에서 다크모드
  - tailwind에서 다크모드는 다크 모드면 text-gray-white가 검정으로 설정되거나 이런식으로 한번에 바꾸는 것은 없나요? 이게 아니면 직접 다 dark: 이렇게 설정해야하는건가요? AI는 2번째 방법만 말해주길래 물어봅니다!