### PR TITLE
[Chore] docker compose 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ node_modules
 # husky 관련
 .husky/_
 .husky/.gitignore
+
+# docker-compose 관련 파일
+
+mysql-data
+redis-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+
+services:
+  mysql:
+    image: mysql:latest
+    container_name: mysql
+    ports:
+      - '3306:3306'
+    environment:
+      MYSQL_ROOT_PASSWORD: dbcadmium
+      MYSQL_DATABASE: preview
+      TZ: Asia/Seoul
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - ./mysql-data:/var/lib/mysql
+
+  redis:
+    image: redis:latest
+    container_name: redis
+    ports:
+      - '6379:6379'
+    command: redis-server --port 6379
+    volumes:
+      - ./redis-data:/data


### PR DESCRIPTION
## 관련 이슈 번호
> - 작성자: 김찬우
> - 작성 날짜: 2024.11.21

- 없음 (편의성 기능)

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- `docker-compose.yml` 추가

## 📝 작업 상세 내역
### 도커 컴포즈 기능 추가

- 앞으로 `MySQL`, `Redis` 등 데브서버에 필요한 부가적인 서버들은 모두 `docker-compose.yml` 에서 실행가능
- `데브서버이므로 공개해도 된다고 판단했음`

```
version: '3'

services:
  mysql:
    image: mysql:latest
    container_name: mysql
    ports:
      - '3306:3306'
    environment:
      MYSQL_ROOT_PASSWORD: dbcadmium
      MYSQL_DATABASE: preview
      TZ: Asia/Seoul
    command:
      - --character-set-server=utf8mb4
      - --collation-server=utf8mb4_unicode_ci
    volumes:
      - ./mysql-data:/var/lib/mysql

  redis:
    image: redis:latest
    container_name: redis
    ports:
      - '6379:6379'
    command: redis-server --port 6379
    volumes:
      - ./redis-data:/data
```

그래서 이제 `.env` 만 공유하면 데브서버 환경 통일 가능합니다!

## 📌 테스트 및 검증 결과

인텔리제이에서는 여기서 실행 가능

<img width="198" alt="image" src="https://github.com/user-attachments/assets/c9ca1920-9ec2-45bc-9388-85c166b0cefe">

또는 도커 데스크탑에서 아래 명령어 실행

```bash
# docker-compose.yml 이 있는 곳에서
docker compose up -d
```

이후 도커 데스크탑에서 확인 가능

<img width="1382" alt="image" src="https://github.com/user-attachments/assets/9b9d2ca3-f667-4bd9-bda8-fd4ff10342bf">

참 쉽죠???

## 💬 다음 작업 또는 논의 사항
- 배포 테스트 해야합니다!
- 태스크 마저 수행할게요. 질문지 핵심 기능 관련해서도 해야겠네요!