### PR TITLE
[Fix] 열려있는 세션이 없을 경우에 대한 예외처리, 세션 리스트 GET API 수정

### DIFF
--- a/backend/src/room/room.repository.ts
+++ b/backend/src/room/room.repository.ts
@@ -15,11 +15,8 @@ export class RoomRepository {
 
     async getAllRoom(): Promise<Record<string, Room>> {
         const redisMap = await this.redisService.getMap("room:*");
-        console.log(redisMap);
 
-        if (!redisMap) return {};
-
-        return Object.entries(redisMap).reduce(
+        return Object.entries(redisMap ?? {}).reduce(
             (acc, [roomId, room]) => {
                 acc[roomId.split(":")[1]] = room as Room;
                 return acc;

--- a/backend/src/room/room.service.ts
+++ b/backend/src/room/room.service.ts
@@ -17,7 +17,7 @@ export class RoomService {
     async getPublicRoom() {
         const rooms = await this.roomRepository.getAllRoom();
 
-        Object.keys(rooms).forEach((roomId) => {
+        Object.keys(rooms ?? {}).forEach((roomId) => {
             if (rooms[roomId].status === "PRIVATE") rooms[roomId] = undefined;
         });
         return rooms;

--- a/backend/src/room/room.service.ts
+++ b/backend/src/room/room.service.ts
@@ -16,11 +16,25 @@ export class RoomService {
 
     async getPublicRoom() {
         const rooms = await this.roomRepository.getAllRoom();
-
-        Object.keys(rooms ?? {}).forEach((roomId) => {
-            if (rooms[roomId].status === "PRIVATE") rooms[roomId] = undefined;
+        const roomList = [];
+        Object.entries(rooms).forEach(([roomId, roomData]) => {
+            if (roomData.status === "PRIVATE") return;
+            roomList.push({
+                id: roomId,
+                title: roomData.title,
+                category: "프론트엔드",
+                inProgress: false,
+                host: {
+                    nickname: "방장",
+                    socketId: roomData.host,
+                },
+                participant: 1,
+                maxParticipant: roomData.maxParticipants,
+                createAt: roomData.createdAt,
+            });
         });
-        return rooms;
+
+        return roomList.sort((a, b) => b.createAt - a.createAt);
     }
 
     async getRoomId(socketId: string) {


### PR DESCRIPTION
## 관련 이슈 번호
> - 작성자: 김찬우
> - 작성 날짜: 2024.11.21


## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- `/api/rooms` 에서, 열려있는 세션이 없을 경우에 대한 예외처리
- 세션 리스트 API 데이터 수정

## 📝 작업 상세 내역

> 지금은 열려있는 세션이 없는 경우 즉, map 객체가 null 일 경우에 Object.entries(redisMap)에서 오류가 발생하고 있습니다. 간단하게 > redisMap ?? [] 혹은 ?? {} 혹은 ?? new Map()으로 처리하면 될 것 같습니다.

아래와 같이 수정했고, 비어있을 때 불러올때 에러가 없고, 빈 객체를 반환하도록 하였습니다.

```ts
async getPublicRoom() {
        const rooms = await this.roomRepository.getAllRoom();

        Object.keys(rooms ?? {}).forEach((roomId) => {
            if (rooms[roomId].status === "PRIVATE") rooms[roomId] = undefined;
        });
        return rooms;
    }
```

### 세션 리스트 API 데이터 수정
- 배열로 수정
- 필요한 데이터들을 반환하도록 수정
- 다만, 현재 당장 없는 기능은 모킹했음
  - 예시 : category : "프론트엔드", nickname : "방장", participants: 1

```ts
async getPublicRoom() {
        const rooms = await this.roomRepository.getAllRoom();
        const roomList = [];
        Object.entries(rooms).forEach(([roomId, roomData]) => {
            if (roomData.status === "PRIVATE") return;
            roomList.push({
                id: roomId,
                title: roomData.title,
                category: "프론트엔드",
                inProgress: false,
                host: {
                    nickname: "방장",
                    socketId: roomData.host,
                },
                participant: 1,
                maxParticipant: roomData.maxParticipants,
                createAt: roomData.createdAt,
            });
        });

        return roomList.sort((a, b) => b.createAt - a.createAt);
    }
```

## 📌 테스트 및 검증 결과

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/432f8fe6-0de1-4f3e-8ec1-a42c3b223d45">

## 💬 다음 작업 또는 논의 사항
- API 필요하신거 언제든 알려주세요
- 성능 이슈는 이후 `성능 진단`부터 제대로 해본 이후로 하면 되니까 괜찮을 것 같습니다.