### PR TITLE
[Feat] 카테고리 시드 데이터 추가

### DIFF
--- a/backend/src/config/typeorm.config.ts
+++ b/backend/src/config/typeorm.config.ts
@@ -26,6 +26,40 @@ export const createDataSource = async (): Promise<DataSource> => {
         transactionalDataSource = addTransactionalDataSource(
             new DataSource(typeOrmConfig)
         );
+
+        await transactionalDataSource.initialize();
+        await seedDatabase(transactionalDataSource);
     }
     return transactionalDataSource;
+};
+
+const seedDatabase = async (dataSource: DataSource) => {
+    const categoryRepository = dataSource.getRepository(Category);
+
+    const categories = [
+        "자료구조",
+        "운영체제",
+        "데이터베이스",
+        "컴퓨터구조",
+        "네트워크",
+        "백엔드",
+        "프론트엔드",
+        "알고리즘",
+        "보안",
+    ];
+
+    // 이미 데이터가 있을 경우 시딩하지 않음
+    const existingCount = await categoryRepository.count();
+    if (existingCount > 0) {
+        return;
+    }
+
+    // 카테고리 데이터 삽입
+    const categoryEntities = categories.map((name) => {
+        const category = new Category();
+        category.name = name;
+        return category;
+    });
+
+    await categoryRepository.save(categoryEntities);
 };


### PR DESCRIPTION
## 관련 이슈 번호
> - 작성자: 송수민
> - 작성 날짜: 2024.11.21

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- 카테고리 시드 데이터 추가

## 📝 작업 상세 내역
### 카테고리 시드 데이터 추가
- 개발자가 직접 시드 데이터를 디비에 추가하지 않아도 되도록 코드로 구현해보았습니다.
```ts
// typeorm.config.ts
export const createDataSource = async (): Promise<DataSource> => {
    if (!transactionalDataSource) {
        transactionalDataSource = addTransactionalDataSource(
            new DataSource(typeOrmConfig)
        );

        await transactionalDataSource.initialize();
        await seedDatabase(transactionalDataSource);
    }
    return transactionalDataSource;
};

const seedDatabase = async (dataSource: DataSource) => {
    const categoryRepository = dataSource.getRepository(Category);

    const categories = [
        "자료구조",
        "운영체제",
        "데이터베이스",
        "컴퓨터구조",
        "네트워크",
        "백엔드",
        "프론트엔드",
        "알고리즘",
        "보안",
    ];

    // 이미 데이터가 있을 경우 시딩하지 않음
    const existingCount = await categoryRepository.count();
    if (existingCount > 0) {
        return;
    }

    // 카테고리 데이터 삽입
    const categoryEntities = categories.map((name) => {
        const category = new Category();
        category.name = name;
        return category;
    });

    await categoryRepository.save(categoryEntities);
};
```