### PR TITLE
[Fix] websocket gateway CORS 허용

### DIFF
--- a/backend/src/room/room.gateway.ts
+++ b/backend/src/room/room.gateway.ts
@@ -18,8 +18,9 @@ import { ReactionDto } from "@/room/dto/reaction.dto";
 import { RoomLeaveService } from "@/room/services/room-leave.service";
 import { RoomCreateService } from "@/room/services/room-create.service";
 import { RoomJoinService } from "@/room/services/room-join.service";
+import { websocketConfig } from "@/websocket/websocket.config";
 
-@WebSocketGateway()
+@WebSocketGateway(websocketConfig)
 export class RoomGateway implements OnGatewayDisconnect {
     private logger: Logger = new Logger("Room Gateway");
 

--- a/backend/src/signaling-server/sig-server.gateway.ts
+++ b/backend/src/signaling-server/sig-server.gateway.ts
@@ -6,8 +6,9 @@ import {
 } from "@nestjs/websockets";
 import { Server } from "socket.io";
 import { EMIT_EVENT, LISTEN_EVENT } from "@/signaling-server/sig-server.event";
+import { websocketConfig } from "@/websocket/websocket.config";
 
-@WebSocketGateway()
+@WebSocketGateway(websocketConfig)
 export class SigServerGateway {
     @WebSocketServer()
     private server: Server;

--- a/backend/src/websocket/websocket.config.ts
+++ b/backend/src/websocket/websocket.config.ts
@@ -1,5 +1,7 @@
+import "dotenv/config";
+
 export const websocketConfig = {
     cors: {
-        origin: "*",
+        origin: process.env.DOMAIN || "*",
     },
 };

--- a/backend/src/websocket/websocket.config.ts
+++ b/backend/src/websocket/websocket.config.ts
@@ -1,0 +1,5 @@
+export const websocketConfig = {
+    cors: {
+        origin: "*",
+    },
+};

--- a/backend/src/websocket/websocket.gateway.ts
+++ b/backend/src/websocket/websocket.gateway.ts
@@ -11,8 +11,9 @@ import Redis from "ioredis";
 import { createAdapter } from "@socket.io/redis-adapter";
 import { WebsocketService } from "@/websocket/websocket.service";
 import { WebsocketRepository } from "@/websocket/websocket.repository";
+import { websocketConfig } from "@/websocket/websocket.config";
 
-@WebSocketGateway()
+@WebSocketGateway(websocketConfig)
 export class WebsocketGateway implements OnGatewayConnection, OnGatewayDisconnect, OnGatewayInit {
     @WebSocketServer()
     private server: Server;


### PR DESCRIPTION

> - 작성자: 김찬우
> - 작성 날짜: 2024.11.26


## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- 세션 리워크 중 누락된 CORS 설정을 허용하였습니다.
<img width="648" alt="image" src="https://github.com/user-attachments/assets/65bab04a-81e9-4cec-8f11-78f7ff8e08ae">


## 📝 작업 상세 내역

- `config` 파일을 분리하여서 설정 값을 저장합니다!
- 갑자기 든 생각인데 `CORS`를 진짜 모두 허용해도 될지 의문이었습니다.
- 그래서 새롭게 프로덕션 환경에서는 저희 도메인만 허용할 수 있도록 이렇게 설정하였습니다.
  - 프로덕션 환경에서는 특정 도메인만 허용하도록 조절할 수 있게 했습니다.
- `dev-be` 에 업로드 되어있으니 프론트엔드분들은 참고하셔서 가져오시길 바랍니다!

```ts
// websocket.config.ts
export const websocketConfig = {
    cors: {
        origin: process.env.DOMAIN || "*",
    },
};
```