### PR TITLE
[Feat] 질문지 스크랩 기능(조회, 스크랩, 스크랩 취소) 구현

### DIFF
--- a/backend/src/question-list/question-list.controller.ts
+++ b/backend/src/question-list/question-list.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Req, Res, UseGuards } from "@nestjs/common";
+import { Body, Controller, Delete, Get, Post, Req, Res, UseGuards } from "@nestjs/common";
 import { QuestionListService } from "./question-list.service";
 import { CreateQuestionListDto } from "./dto/create-question-list.dto";
 import { GetAllQuestionListDto } from "./dto/get-all-question-list.dto";
@@ -208,6 +208,42 @@ export class QuestionListController {
             return res.send({
                 success: false,
                 message: "Failed to scrap question list.",
+                error: error.message,
+            });
+        }
+    }
+
+    @Delete("scrap")
+    @UseGuards(AuthGuard("jwt"))
+    async unscrapQuestionList(
+        @Res() res,
+        @JwtPayload() token: IJwtPayload,
+        @Body() body: { questionListId: number }
+    ) {
+        try {
+            const userId = token.userId;
+            const { questionListId } = body;
+
+            const unscrappedQuestionList = await this.questionListService.unscrapQuestionList(
+                questionListId,
+                userId
+            );
+
+            if (unscrappedQuestionList.affected) {
+                return res.send({
+                    success: true,
+                    message: "Question list unscrapped successfully.",
+                });
+            } else {
+                return res.send({
+                    success: false,
+                    message: "Failed to unscrap question list.",
+                });
+            }
+        } catch (error) {
+            return res.send({
+                success: false,
+                message: "Failed to unscrap question list.",
                 error: error.message,
             });
         }

--- a/backend/src/question-list/question-list.controller.ts
+++ b/backend/src/question-list/question-list.controller.ts
@@ -159,6 +159,29 @@ export class QuestionListController {
         }
     }
 
+    @Get("scrap")
+    @UseGuards(AuthGuard("jwt"))
+    async getScrappedQuestionLists(@Res() res, @JwtPayload() token: IJwtPayload) {
+        try {
+            const userId = token.userId;
+            const scrappedQuestionLists =
+                await this.questionListService.getScrappedQuestionLists(userId);
+            return res.send({
+                success: true,
+                message: "Scrapped question lists received successfully.",
+                data: {
+                    scrappedQuestionLists,
+                },
+            });
+        } catch (error) {
+            return res.send({
+                success: false,
+                message: "Failed to get scrapped question lists.",
+                error: error.message,
+            });
+        }
+    }
+
     @Post("scrap")
     @UseGuards(AuthGuard("jwt"))
     async scrapQuestionList(

--- a/backend/src/question-list/question-list.controller.ts
+++ b/backend/src/question-list/question-list.controller.ts
@@ -1,20 +1,11 @@
-import {
-    Body,
-    Controller,
-    Get,
-    Post,
-    Req,
-    Res,
-    UseGuards,
-} from "@nestjs/common";
+import { Body, Controller, Get, Post, Req, Res, UseGuards } from "@nestjs/common";
 import { QuestionListService } from "./question-list.service";
 import { CreateQuestionListDto } from "./dto/create-question-list.dto";
-import { CreateQuestionDto } from "./dto/create-question.dto";
 import { GetAllQuestionListDto } from "./dto/get-all-question-list.dto";
 import { QuestionListContentsDto } from "./dto/question-list-contents.dto";
 import { AuthGuard } from "@nestjs/passport";
-import { JwtPayload } from "../auth/jwt/jwt.decorator";
-import { IJwtPayload } from "../auth/jwt/jwt.model";
+import { JwtPayload } from "@/auth/jwt/jwt.decorator";
+import { IJwtPayload } from "@/auth/jwt/jwt.model";
 import { MyQuestionListDto } from "./dto/my-question-list.dto";
 
 @Controller("question-list")
@@ -70,9 +61,7 @@ export class QuestionListController {
 
             // 질문지 생성
             const { createdQuestionList, createdQuestions } =
-                await this.questionListService.createQuestionList(
-                    createQuestionListDto
-                );
+                await this.questionListService.createQuestionList(createQuestionListDto);
 
             return res.send({
                 success: true,
@@ -102,9 +91,7 @@ export class QuestionListController {
         try {
             const { categoryName } = body;
             const allQuestionLists: GetAllQuestionListDto[] =
-                await this.questionListService.getAllQuestionListsByCategoryName(
-                    categoryName
-                );
+                await this.questionListService.getAllQuestionListsByCategoryName(categoryName);
             return res.send({
                 success: true,
                 message: "All question lists received successfully.",
@@ -132,9 +119,7 @@ export class QuestionListController {
         try {
             const { questionListId } = body;
             const questionListContents: QuestionListContentsDto =
-                await this.questionListService.getQuestionListContents(
-                    questionListId
-                );
+                await this.questionListService.getQuestionListContents(questionListId);
             return res.send({
                 success: true,
                 message: "Question list contents received successfully.",
@@ -169,6 +154,37 @@ export class QuestionListController {
             return res.send({
                 success: false,
                 message: "Failed to get my question lists.",
+                error: error.message,
+            });
+        }
+    }
+
+    @Post("scrap")
+    @UseGuards(AuthGuard("jwt"))
+    async scrapQuestionList(
+        @Res() res,
+        @JwtPayload() token: IJwtPayload,
+        @Body() body: { questionListId: number }
+    ) {
+        try {
+            const userId = token.userId;
+            const { questionListId } = body;
+            const scrappedQuestionList = await this.questionListService.scrapQuestionList(
+                questionListId,
+                userId
+            );
+
+            return res.send({
+                success: true,
+                message: "Question list is scrapped successfully.",
+                data: {
+                    scrappedQuestionList,
+                },
+            });
+        } catch (error) {
+            return res.send({
+                success: false,
+                message: "Failed to scrap question list.",
                 error: error.message,
             });
         }

--- a/backend/src/question-list/question-list.controller.ts
+++ b/backend/src/question-list/question-list.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Post, Req, Res, UseGuards } from "@nestjs/common";
+import { Body, Controller, Delete, Get, Param, Post, Req, Res, UseGuards } from "@nestjs/common";
 import { QuestionListService } from "./question-list.service";
 import { CreateQuestionListDto } from "./dto/create-question-list.dto";
 import { GetAllQuestionListDto } from "./dto/get-all-question-list.dto";
@@ -213,17 +213,15 @@ export class QuestionListController {
         }
     }
 
-    @Delete("scrap")
+    @Delete("scrap/:questionListId")
     @UseGuards(AuthGuard("jwt"))
     async unscrapQuestionList(
         @Res() res,
         @JwtPayload() token: IJwtPayload,
-        @Body() body: { questionListId: number }
+        @Param("questionListId") questionListId: number
     ) {
         try {
             const userId = token.userId;
-            const { questionListId } = body;
-
             const unscrappedQuestionList = await this.questionListService.unscrapQuestionList(
                 questionListId,
                 userId

--- a/backend/src/question-list/question-list.entity.ts
+++ b/backend/src/question-list/question-list.entity.ts
@@ -30,14 +30,19 @@ export class QuestionList {
     @Column()
     userId: number;
 
-    @ManyToOne(() => User, (user) => user.questionLists)
+    @ManyToOne(() => User, (user) => user.questionLists, {
+        onDelete: "CASCADE",
+    })
     user: User;
 
-    @OneToMany(() => Question, (question) => question.questionList)
+    @OneToMany(() => Question, (question) => question.questionList, {
+        cascade: true,
+    })
     questions: Question[];
 
     @ManyToMany(() => Category, (category) => category.questionLists, {
         cascade: true,
+        onDelete: "CASCADE",
     })
     @JoinTable({
         name: "question_list_category",

--- a/backend/src/question-list/question-list.entity.ts
+++ b/backend/src/question-list/question-list.entity.ts
@@ -7,7 +7,7 @@ import {
     ManyToMany,
     JoinTable,
 } from "typeorm";
-import { User } from "../user/user.entity";
+import { User } from "@/user/user.entity";
 import { Question } from "./question.entity";
 import { Category } from "./category.entity";
 
@@ -42,9 +42,12 @@ export class QuestionList {
     @JoinTable({
         name: "question_list_category",
         joinColumn: {
-            name: "questionListId",
+            name: "question_list_id",
             referencedColumnName: "id",
         },
     })
     categories: Category[];
+
+    @ManyToMany(() => User, (user) => user.scrappedQuestionLists)
+    scrappedByUsers: User[];
 }

--- a/backend/src/question-list/question-list.module.ts
+++ b/backend/src/question-list/question-list.module.ts
@@ -2,10 +2,11 @@ import { Module } from "@nestjs/common";
 import { QuestionListController } from "./question-list.controller";
 import { QuestionListService } from "./question-list.service";
 import { QuestionListRepository } from "./question-list.repository";
+import { UserRepository } from "@/user/user.repository";
 
 @Module({
     controllers: [QuestionListController],
-    providers: [QuestionListService, QuestionListRepository],
+    providers: [QuestionListService, QuestionListRepository, UserRepository],
     exports: [QuestionListRepository],
 })
 export class QuestionListModule {}

--- a/backend/src/question-list/question-list.repository.ts
+++ b/backend/src/question-list/question-list.repository.ts
@@ -3,7 +3,7 @@ import { DataSource, In } from "typeorm";
 import { QuestionList } from "./question-list.entity";
 import { Question } from "./question.entity";
 import { Category } from "./category.entity";
-import { User } from "../user/user.entity";
+import { User } from "@/user/user.entity";
 
 @Injectable()
 export class QuestionListRepository {
@@ -35,12 +35,16 @@ export class QuestionListRepository {
     }
 
     async findCategoryNamesByQuestionListId(questionListId: number) {
-        const questionList = await this.dataSource.getRepository(QuestionList).findOne({
-            where: { id: questionListId },
-            relations: ["categories"], // 질문지와 관련된 카테고리도 함께 조회
-        });
+        const questionList = await this.dataSource
+            .getRepository(QuestionList)
+            .findOne({
+                where: { id: questionListId },
+                relations: ["categories"], // 질문지와 관련된 카테고리도 함께 조회
+            });
 
-        return questionList ? questionList.categories.map((category) => category.name) : [];
+        return questionList
+            ? questionList.categories.map((category) => category.name)
+            : [];
     }
 
     async findCategoriesByNames(categoryNames: string[]) {
@@ -85,5 +89,24 @@ export class QuestionListRepository {
                 questionListId,
             })
             .getCount();
+    }
+
+    scrapQuestionList(questionListId: number, userId: number) {
+        return this.dataSource
+            .createQueryBuilder()
+            .insert()
+            .into("user_question_list")
+            .values({
+                user_id: userId,
+                question_list_id: questionListId,
+            })
+            .orIgnore()
+            .execute();
+    }
+
+    getScrappedQuestionListsByUser(user: User) {
+        return this.dataSource.getRepository(QuestionList).find({
+            where: { scrappedByUsers: user },
+        });
     }
 }

--- a/backend/src/question-list/question-list.repository.ts
+++ b/backend/src/question-list/question-list.repository.ts
@@ -113,4 +113,14 @@ export class QuestionListRepository {
             where: { scrappedByUsers: user },
         });
     }
+
+    unscrapQuestionList(questionListId: number, userId: number) {
+        return this.dataSource
+            .createQueryBuilder()
+            .delete()
+            .from("user_question_list")
+            .where("user_id = :userId", { userId })
+            .andWhere("question_list_id = :questionListId", { questionListId })
+            .execute();
+    }
 }

--- a/backend/src/question-list/question-list.repository.ts
+++ b/backend/src/question-list/question-list.repository.ts
@@ -9,6 +9,14 @@ import { User } from "@/user/user.entity";
 export class QuestionListRepository {
     constructor(private dataSource: DataSource) {}
 
+    createQuestionList(questionList: QuestionList) {
+        return this.dataSource.getRepository(QuestionList).save(questionList);
+    }
+
+    async createQuestions(questions: Question[]) {
+        return this.dataSource.getRepository(Question).save(questions);
+    }
+
     findPublicQuestionLists() {
         return this.dataSource.getRepository(QuestionList).find({
             where: { isPublic: true },
@@ -35,16 +43,12 @@ export class QuestionListRepository {
     }
 
     async findCategoryNamesByQuestionListId(questionListId: number) {
-        const questionList = await this.dataSource
-            .getRepository(QuestionList)
-            .findOne({
-                where: { id: questionListId },
-                relations: ["categories"], // 질문지와 관련된 카테고리도 함께 조회
-            });
+        const questionList = await this.dataSource.getRepository(QuestionList).findOne({
+            where: { id: questionListId },
+            relations: ["categories"], // 질문지와 관련된 카테고리도 함께 조회
+        });
 
-        return questionList
-            ? questionList.categories.map((category) => category.name)
-            : [];
+        return questionList ? questionList.categories.map((category) => category.name) : [];
     }
 
     async findCategoriesByNames(categoryNames: string[]) {

--- a/backend/src/question-list/question-list.service.ts
+++ b/backend/src/question-list/question-list.service.ts
@@ -193,4 +193,8 @@ export class QuestionListService {
 
         return questionList;
     }
+
+    async unscrapQuestionList(questionListId: number, userId: number) {
+        return await this.questionListRepository.unscrapQuestionList(questionListId, userId);
+    }
 }

--- a/backend/src/question-list/question-list.service.ts
+++ b/backend/src/question-list/question-list.service.ts
@@ -172,10 +172,13 @@ export class QuestionListService {
         return categories;
     }
 
-    async scrapQuestionList(questionListId: number, userId: number) {
-        // 유효한 유저 id 인지 확인
+    async getScrappedQuestionLists(userId: number) {
         const user = await this.userRepository.getUserByUserId(userId);
-        if (!user) throw new Error("User not found.");
+        return await this.questionListRepository.getScrappedQuestionListsByUser(user);
+    }
+
+    async scrapQuestionList(questionListId: number, userId: number) {
+        const user = await this.userRepository.getUserByUserId(userId);
 
         // 유효한 question list id 인지 확인
         const questionList = await this.questionListRepository.getQuestionListById(questionListId);

--- a/backend/src/question-list/question-list.service.ts
+++ b/backend/src/question-list/question-list.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { QuestionListRepository } from "./question-list.repository";
+import { UserRepository } from "@/user/user.repository";
 import { CreateQuestionListDto } from "./dto/create-question-list.dto";
 import { GetAllQuestionListDto } from "./dto/get-all-question-list.dto";
 import { QuestionListContentsDto } from "./dto/question-list-contents.dto";
@@ -12,26 +13,22 @@ import { Question } from "./question.entity";
 export class QuestionListService {
     constructor(
         private readonly dataSource: DataSource,
-        private readonly questionListRepository: QuestionListRepository
+        private readonly questionListRepository: QuestionListRepository,
+        private readonly userRepository: UserRepository
     ) {}
 
     async getAllQuestionLists() {
         const allQuestionLists: GetAllQuestionListDto[] = [];
 
-        const publicQuestionLists =
-            await this.questionListRepository.findPublicQuestionLists();
+        const publicQuestionLists = await this.questionListRepository.findPublicQuestionLists();
 
         for (const publicQuestionList of publicQuestionLists) {
             const { id, title, usage } = publicQuestionList;
             const categoryNames: string[] =
-                await this.questionListRepository.findCategoryNamesByQuestionListId(
-                    id
-                );
+                await this.questionListRepository.findCategoryNamesByQuestionListId(id);
 
             const questionCount =
-                await this.questionListRepository.getQuestionCountByQuestionListId(
-                    id
-                );
+                await this.questionListRepository.getQuestionCountByQuestionListId(id);
 
             const questionList: GetAllQuestionListDto = {
                 id,
@@ -48,29 +45,22 @@ export class QuestionListService {
     async getAllQuestionListsByCategoryName(categoryName: string) {
         const allQuestionLists: GetAllQuestionListDto[] = [];
 
-        const categoryId =
-            await this.questionListRepository.getCategoryIdByName(categoryName);
+        const categoryId = await this.questionListRepository.getCategoryIdByName(categoryName);
 
         if (!categoryId) {
             return [];
         }
 
         const publicQuestionLists =
-            await this.questionListRepository.findPublicQuestionListsByCategoryId(
-                categoryId
-            );
+            await this.questionListRepository.findPublicQuestionListsByCategoryId(categoryId);
 
         for (const publicQuestionList of publicQuestionLists) {
             const { id, title, usage } = publicQuestionList;
             const categoryNames: string[] =
-                await this.questionListRepository.findCategoryNamesByQuestionListId(
-                    id
-                );
+                await this.questionListRepository.findCategoryNamesByQuestionListId(id);
 
             const questionCount =
-                await this.questionListRepository.getQuestionCountByQuestionListId(
-                    id
-                );
+                await this.questionListRepository.getQuestionCountByQuestionListId(id);
 
             const questionList: GetAllQuestionListDto = {
                 id,
@@ -86,8 +76,7 @@ export class QuestionListService {
 
     // 질문 생성 메서드
     async createQuestionList(createQuestionListDto: CreateQuestionListDto) {
-        const { title, contents, categoryNames, isPublic, userId } =
-            createQuestionListDto;
+        const { title, contents, categoryNames, isPublic, userId } = createQuestionListDto;
 
         const categories = await this.findCategoriesByNames(categoryNames);
 
@@ -101,8 +90,7 @@ export class QuestionListService {
             questionListDto.isPublic = isPublic;
             questionListDto.userId = userId;
 
-            const createdQuestionList =
-                await queryRunner.manager.save(questionListDto);
+            const createdQuestionList = await queryRunner.manager.save(questionListDto);
 
             const questions = contents.map((content, index) => {
                 const question = new Question();
@@ -113,8 +101,7 @@ export class QuestionListService {
                 return question;
             });
 
-            const createdQuestions =
-                await queryRunner.manager.save(questions);
+            const createdQuestions = await queryRunner.manager.save(questions);
 
             await queryRunner.commitTransaction();
 
@@ -128,24 +115,16 @@ export class QuestionListService {
     }
 
     async getQuestionListContents(questionListId: number) {
-        const questionList =
-            await this.questionListRepository.getQuestionListById(
-                questionListId
-            );
+        const questionList = await this.questionListRepository.getQuestionListById(questionListId);
         const { id, title, usage, userId } = questionList;
 
         const contents =
-            await this.questionListRepository.getContentsByQuestionListId(
-                questionListId
-            );
+            await this.questionListRepository.getContentsByQuestionListId(questionListId);
 
         const categoryNames =
-            await this.questionListRepository.findCategoryNamesByQuestionListId(
-                questionListId
-            );
+            await this.questionListRepository.findCategoryNamesByQuestionListId(questionListId);
 
-        const username =
-            await this.questionListRepository.getUsernameById(userId);
+        const username = await this.questionListRepository.getUsernameById(userId);
 
         const questionListContents: QuestionListContentsDto = {
             id,
@@ -160,21 +139,15 @@ export class QuestionListService {
     }
 
     async getMyQuestionLists(userId: number) {
-        const questionLists =
-            await this.questionListRepository.getQuestionListsByUserId(userId);
+        const questionLists = await this.questionListRepository.getQuestionListsByUserId(userId);
 
         const myQuestionLists: MyQuestionListDto[] = [];
         for (const myQuestionList of questionLists) {
             const { id, title, isPublic, usage } = myQuestionList;
             const categoryNames: string[] =
-                await this.questionListRepository.findCategoryNamesByQuestionListId(
-                    id
-                );
+                await this.questionListRepository.findCategoryNamesByQuestionListId(id);
 
-            const contents =
-                await this.questionListRepository.getContentsByQuestionListId(
-                    id
-                );
+            const contents = await this.questionListRepository.getContentsByQuestionListId(id);
 
             const questionList: MyQuestionListDto = {
                 id,
@@ -190,15 +163,40 @@ export class QuestionListService {
     }
 
     async findCategoriesByNames(categoryNames: string[]) {
-        const categories =
-            await this.questionListRepository.findCategoriesByNames(
-                categoryNames
-            );
+        const categories = await this.questionListRepository.findCategoriesByNames(categoryNames);
 
         if (categories.length !== categoryNames.length) {
             throw new Error("Some category names were not found.");
         }
 
         return categories;
+    }
+
+    async scrapQuestionList(questionListId: number, userId: number) {
+        // 유효한 유저 id 인지 확인
+        const user = await this.userRepository.getUserByUserId(userId);
+        if (!user) throw new Error("User not found.");
+
+        // 유효한 question list id 인지 확인
+        const questionList = await this.questionListRepository.getQuestionListById(questionListId);
+        if (!questionList) throw new Error("Question list not found.");
+
+        // 스크랩하려는 질문지가 내가 만든 질문지인지 확인
+        const myQuestionLists = await this.questionListRepository.getQuestionListsByUserId(userId);
+        const isMyQuestionList = myQuestionLists.some((list) => list.id === questionListId);
+        if (isMyQuestionList) throw new Error("Can't scrap my question list.");
+
+        // 스크랩하려는 질문지가 이미 스크랩한 질문지인지 확인
+        const alreadyScrappedQuestionLists =
+            await this.questionListRepository.getScrappedQuestionListsByUser(user);
+        const isAlreadyScrapped = alreadyScrappedQuestionLists.some(
+            (list) => list.id === questionListId
+        );
+        if (isAlreadyScrapped) throw new Error("This question list is already scrapped.");
+
+        // 질문지 스크랩
+        await this.questionListRepository.scrapQuestionList(questionListId, userId);
+
+        return questionList;
     }
 }

--- a/backend/src/question-list/question.entity.ts
+++ b/backend/src/question-list/question.entity.ts
@@ -17,6 +17,8 @@ export class Question {
     @Column()
     questionListId: number;
 
-    @ManyToOne(() => QuestionList, (questionList) => questionList.questions)
+    @ManyToOne(() => QuestionList, (questionList) => questionList.questions, {
+        onDelete: "CASCADE",
+    })
     questionList: QuestionList;
 }

--- a/backend/src/user/dto/user.dto.ts
+++ b/backend/src/user/dto/user.dto.ts
@@ -1,7 +1,10 @@
+import { QuestionList } from "@/question-list/question-list.entity";
+
 export interface UserDto {
     loginId?: string;
     passwordHash?: string;
     githubId?: number;
     username: string;
     refreshToken: string;
+    scrappedQuestionLists: QuestionList[];
 }

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -1,11 +1,4 @@
-import {
-    Entity,
-    PrimaryGeneratedColumn,
-    Column,
-    OneToMany,
-    ManyToMany,
-    JoinTable,
-} from "typeorm";
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToMany, JoinTable } from "typeorm";
 import { QuestionList } from "@/question-list/question-list.entity";
 
 @Entity()
@@ -33,13 +26,15 @@ export class User {
     @Column({ nullable: true, unique: true })
     githubId: number;
 
-    @OneToMany(() => QuestionList, (questionList) => questionList.user)
+    @OneToMany(() => QuestionList, (questionList) => questionList.user, {
+        cascade: true,
+    })
     questionLists: QuestionList[];
 
-    @ManyToMany(
-        () => QuestionList,
-        (questionList) => questionList.scrappedByUsers
-    )
+    @ManyToMany(() => QuestionList, (questionList) => questionList.scrappedByUsers, {
+        cascade: true,
+        onDelete: "CASCADE",
+    })
     @JoinTable({
         name: "user_question_list",
         joinColumn: {

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -1,5 +1,12 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from "typeorm";
-import { QuestionList } from "../question-list/question-list.entity";
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    OneToMany,
+    ManyToMany,
+    JoinTable,
+} from "typeorm";
+import { QuestionList } from "@/question-list/question-list.entity";
 
 @Entity()
 export class User {
@@ -28,4 +35,17 @@ export class User {
 
     @OneToMany(() => QuestionList, (questionList) => questionList.user)
     questionLists: QuestionList[];
+
+    @ManyToMany(
+        () => QuestionList,
+        (questionList) => questionList.scrappedByUsers
+    )
+    @JoinTable({
+        name: "user_question_list",
+        joinColumn: {
+            name: "user_id",
+            referencedColumnName: "id",
+        },
+    })
+    scrappedQuestionLists: QuestionList[];
 }


### PR DESCRIPTION
## 관련 이슈 번호
> - 작성자: 송수민
> - 작성 날짜: 2024.11.26

- #133 
- #134 
- #218 
- #219 
- #232 
- #233 

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- 스크랩 기능을 위한 user_question_list 엔티티 구현
- 질문지 스크랩 기능 구현
  - 스크랩한 질문지 조회 기능
  - 질문지 스크랩 기능
  - 스크랩한 질문지 스크랩 취소(unscrap) 기능

## 📝 작업 상세 내역
### 스크랩 기능을 위한 user_question_list 엔티티 구현
- 스크랩 기능을 위해 user와 question_list 테이블을 다대다 관계로 연결해줘야 했습니다.
- typeorm의 ManyToMany로 User entity 파일에 다대다 관계를 설정해줬습니다.
  - 둘 중 user에 관계를 정의한 이유는`다대다 관계일 경우 관계의 주체가 되는 테이블에 ManyToMany 정의를 하는 것이 일반적이다.`라고 배웠기 때문입니다. 
```ts
// user.entity.ts
import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToMany, JoinTable } from "typeorm";
import { QuestionList } from "@/question-list/question-list.entity";

@Entity()
export class User {
    private static LOGIN_ID_MAX_LEN = 20;
    private static PASSWORD_HASH_MAX_LEN = 256;
    private static USERNAME_MAX_LEN = 20;
    private static REFRESH_TOKEN_MAX_LEN = 200;

    @PrimaryGeneratedColumn()
    id: number;

    @Column({ length: User.LOGIN_ID_MAX_LEN, nullable: true, unique: true })
    loginId: string;

    @Column({ length: User.PASSWORD_HASH_MAX_LEN, nullable: true })
    passwordHash: string;

    @Column({ length: User.USERNAME_MAX_LEN, unique: true })
    username: string;

    @Column({ length: User.REFRESH_TOKEN_MAX_LEN, nullable: true })
    refreshToken: string;

    @Column({ nullable: true, unique: true })
    githubId: number;

    @OneToMany(() => QuestionList, (questionList) => questionList.user, {
        cascade: true,
    })
    questionLists: QuestionList[];
    
    // 스크랩 기능을 위한 다대다 관계 설정
    @ManyToMany(() => QuestionList, (questionList) => questionList.scrappedByUsers, {
        cascade: true,
        onDelete: "CASCADE",
    })
    @JoinTable({
        name: "user_question_list",
        joinColumn: {
            name: "user_id",
            referencedColumnName: "id",
        },
    })
    scrappedQuestionLists: QuestionList[];
}
```

### 질문지 스크랩 기능 구현
- 질문지 스크랩 기능을 구현했습니다. 
- 총 세 가지 기능(스크랩한 질문지 조회 기능, 질문지 스크랩 기능, 스크랩한 질문지 스크랩 취소 기능)이 있습니다.
- 관련된 임의 API 명세서는 노션에 정리해두었습니다.
- 해당 API에서 더 필요한 데이터는 없는지에 관해 프론트 개발자분들의 의견이 궁금합니다.
  - [질문지 스크랩 기능 API 명세서](https://www.notion.so/HTTP-API-7e00941833c94829a88e408a3f35f80b?pvs=4#bc6bae452dd44658a608a5e8880fa97b)

## 📌 테스트 및 검증 결과
- 스크랩한 질문지 조회 기능
![image](https://github.com/user-attachments/assets/64c9195f-591f-4af5-a3a3-939ed853f880)

- 질문지 스크랩 기능
![image](https://github.com/user-attachments/assets/f666df48-db36-4504-a0fe-2776e651b385)

- 스크랩 취소 기능
  - delete 메서드를 사용하면서 처음에는 body로 question list id를 받다가 이후에 url param으로 받도록 수정했습니다!
![image](https://github.com/user-attachments/assets/71664c8e-077e-416a-a0f7-66f32f0a091f)

## 💬 다음 작업 또는 논의 사항
- 질문지 삭제 기능
- 질문 추가, 수정, 삭제 기능