### PR TITLE
[Fix] index already exists 문제 해결 (패키지 출시함)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@moozeh/nestjs-redis-om": "^0.1.4",
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/jwt": "^10.2.0",
@@ -32,13 +33,12 @@
     "@socket.io/redis-adapter": "^8.3.0",
     "@types/passport-jwt": "^4.0.1",
     "axios": "^1.7.7",
-    "cookie-parser": "^1.4.7",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "cookie-parser": "^1.4.7",
     "dotenv": "^16.4.5",
     "ioredis": "^5.4.1",
     "mysql2": "^3.11.4",
-    "nestjs-redis-om": "^0.1.2",
     "passport": "^0.7.0",
     "passport-custom": "^1.1.1",
     "passport-jwt": "^4.0.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,7 +12,7 @@ import "dotenv/config";
 
 import { createDataSource, typeOrmConfig } from "./config/typeorm.config";
 import { QuestionListModule } from "./question-list/question-list.module";
-import { RedisOmModule } from "nestjs-redis-om";
+import { RedisOmModule } from "@moozeh/nestjs-redis-om";
 import { SigServerModule } from "@/signaling-server/sig-server.module";
 
 @Module({

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,9 +1,6 @@
 import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
-import {
-    initializeTransactionalContext,
-    StorageDriver,
-} from "typeorm-transactional";
+import { initializeTransactionalContext, StorageDriver } from "typeorm-transactional";
 import * as cookieParser from "cookie-parser";
 
 async function bootstrap() {

--- a/backend/src/room/room.entity.ts
+++ b/backend/src/room/room.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Field, Schema } from "nestjs-redis-om";
+import { Entity, Field, Schema } from "@moozeh/nestjs-redis-om";
 
 export interface Connection {
     socketId: string;

--- a/backend/src/room/room.module.ts
+++ b/backend/src/room/room.module.ts
@@ -3,7 +3,7 @@ import { RoomService } from "./services/room.service";
 import { RoomGateway } from "./room.gateway";
 import { RoomRepository } from "./room.repository";
 import { RoomController } from "./room.controller";
-import { RedisOmModule } from "nestjs-redis-om";
+import { RedisOmModule } from "@moozeh/nestjs-redis-om";
 import { RoomEntity } from "./room.entity";
 import { RoomLeaveService } from "@/room/services/room-leave.service";
 import { RoomHostService } from "@/room/services/room-host.service";

--- a/backend/src/room/room.repository.ts
+++ b/backend/src/room/room.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@nestjs/common";
-import { InjectRepository } from "nestjs-redis-om";
+import { InjectRepository } from "@moozeh/nestjs-redis-om";
 import { Repository } from "redis-om";
 import { RoomEntity } from "@/room/room.entity";
 import { RoomDto } from "@/room/dto/room.dto";

--- a/backend/src/websocket/websocket.entity.ts
+++ b/backend/src/websocket/websocket.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Field, Schema } from "nestjs-redis-om";
+import { Entity, Field, Schema } from "@moozeh/nestjs-redis-om";
 
 @Schema("socket")
 export class WebsocketEntity extends Entity {

--- a/backend/src/websocket/websocket.module.ts
+++ b/backend/src/websocket/websocket.module.ts
@@ -2,7 +2,7 @@ import { Global, Module } from "@nestjs/common";
 import { WebsocketService } from "@/websocket/websocket.service";
 import { WebsocketGateway } from "@/websocket/websocket.gateway";
 import { WebsocketRepository } from "@/websocket/websocket.repository";
-import { RedisOmModule } from "nestjs-redis-om";
+import { RedisOmModule } from "@moozeh/nestjs-redis-om";
 import { RoomEntity } from "@/room/room.entity";
 import { WebsocketEntity } from "@/websocket/websocket.entity";
 

--- a/backend/src/websocket/websocket.repository.ts
+++ b/backend/src/websocket/websocket.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { Socket } from "socket.io";
-import { InjectRepository } from "nestjs-redis-om";
+import { InjectRepository } from "@moozeh/nestjs-redis-om";
 import { Repository } from "redis-om";
 import { WebsocketEntity } from "@/websocket/websocket.entity";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   backend:
     dependencies:
+      '@moozeh/nestjs-redis-om':
+        specifier: ^0.1.4
+        version: 0.1.4(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)(redis-om@0.4.7)(reflect-metadata@0.2.2)
       '@nestjs/common':
         specifier: ^10.0.0
         version: 10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -71,9 +74,6 @@ importers:
       mysql2:
         specifier: ^3.11.4
         version: 3.11.4
-      nestjs-redis-om:
-        specifier: ^0.1.2
-        version: 0.1.2(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)(redis-om@0.4.7)(reflect-metadata@0.2.2)
       passport:
         specifier: ^0.7.0
         version: 0.7.0
@@ -1041,6 +1041,14 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
+  '@moozeh/nestjs-redis-om@0.1.4':
+    resolution: {integrity: sha512-p0UT1WccsLNKOpa5E69fknJZFZAbK2LOImK4JWuuXtGnFJ2DSGtZ8Jbm4TNV6VkdL6x5yqg8YeX44DdZQHuZfA==}
+    peerDependencies:
+      '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0
+      '@nestjs/core': ^8.0.0 || ^9.0.0 || ^10.0.0
+      redis-om: ^0.4.3
+      reflect-metadata: ^0.1.13 || ^0.2.0
+
   '@nestjs/cli@10.4.5':
     resolution: {integrity: sha512-FP7Rh13u8aJbHe+zZ7hM0CC4785g9Pw4lz4r2TTgRtf0zTxSWMkJaPEwyjX8SK9oWK2GsYxl+fKpwVZNbmnj9A==}
     engines: {node: '>= 16.14'}
@@ -1322,6 +1330,11 @@ packages:
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
+  '@socket.io/redis-adapter@8.3.0':
+    resolution: {integrity: sha512-ly0cra+48hDmChxmIpnESKrc94LjRL80TEmZVscuQ/WWkRP81nNj8W8cCGMqbI4L6NCuAaPRSzZF1a9GlAxxnA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      socket.io-adapter: ^2.5.4
 
   '@sqltools/formatter@1.2.5':
     resolution: {integrity: sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==}
@@ -1329,24 +1342,19 @@ packages:
   '@tanstack/query-core@5.60.6':
     resolution: {integrity: sha512-tI+k0KyCo1EBJ54vxK1kY24LWj673ujTydCZmzEZKAew4NqZzTaVQJEuaG1qKj2M03kUHN46rchLRd+TxVq/zQ==}
 
-  '@tanstack/query-devtools@5.59.20':
-    resolution: {integrity: sha512-vxhuQ+8VV4YWQSFxQLsuM+dnEKRY7VeRzpNabFXdhEwsBYLrjXlF1pM38A8WyKNLqZy8JjyRO8oP4Wd/oKHwuQ==}
+  '@tanstack/query-devtools@5.61.3':
+    resolution: {integrity: sha512-AoRco+DMw7Xy9fFs+5BxBop82YPKs1/tWpTPoO1iYVwPLmAU+znnLfWyZ8Qr5OiEqoS0dCyEe6F5V11/JkCK/A==}
 
-  '@tanstack/react-query-devtools@5.60.6':
-    resolution: {integrity: sha512-b55QgJs2PSzOtLdE3p9fxPOPmeXXfkzcsyVBFFyXwINIilSwz/wWoz2D5fwg5Vbp60CX34LccstzryU6Bg6Rqw==}
+  '@tanstack/react-query-devtools@5.61.3':
+    resolution: {integrity: sha512-bR/TaiOSqTq0M5dmYY+pJeSnl5QAuCaRRmJg+Q5hEqt6uTHgKz5WO4jdi8BywRJiZhpXLirlUAIOXJsZ8ukqSA==}
     peerDependencies:
-      '@tanstack/react-query': ^5.60.6
+      '@tanstack/react-query': ^5.61.3
       react: ^18 || ^19
 
-  '@tanstack/react-query@5.60.6':
-    resolution: {integrity: sha512-FUzSDaiPkuZCmuGqrixfRRXJV9u+nrUh9lAlA5Q3ZFrOw1Js1VeBfxi1NIcJO3ZWJdKceBqKeBJdNcWStCYZnw==}
-
-  '@socket.io/redis-adapter@8.3.0':
-    resolution: {integrity: sha512-ly0cra+48hDmChxmIpnESKrc94LjRL80TEmZVscuQ/WWkRP81nNj8W8cCGMqbI4L6NCuAaPRSzZF1a9GlAxxnA==}
-    engines: {node: '>=10.0.0'}
-
+  '@tanstack/react-query@5.61.3':
+    resolution: {integrity: sha512-c3Oz9KaCBapGkRewu7AJLhxE9BVqpMcHsd3KtFxSd7FSCu2qGwqfIN37zbSGoyk6Ix9LGZBNHQDPI6GpWABnmA==}
     peerDependencies:
-      socket.io-adapter: ^2.5.4
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -3501,14 +3509,6 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  nestjs-redis-om@0.1.2:
-    resolution: {integrity: sha512-QTY0EkpIB+Fdm0KXs7fzpgLbF0NJumEcyZ1dA4Fi0/FlPEc4QirFP6Qj9QdkxIIzdg2yi+MB6LIZ3pflSiUEMA==}
-    peerDependencies:
-      '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0
-      '@nestjs/core': ^8.0.0 || ^9.0.0 || ^10.0.0
-      redis-om: ^0.4.3
-      reflect-metadata: ^0.1.13 || ^0.2.0
-
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
@@ -5657,6 +5657,14 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
+  '@moozeh/nestjs-redis-om@0.1.4(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)(redis-om@0.4.7)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/core': 10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      redis-om: 0.4.7
+      reflect-metadata: 0.2.2
+      uuid: 9.0.1
+
   '@nestjs/cli@10.4.5':
     dependencies:
       '@angular-devkit/core': 17.3.8(chokidar@3.6.0)
@@ -5942,6 +5950,8 @@ snapshots:
       uid2: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  '@sqltools/formatter@1.2.5': {}
 
   '@tanstack/query-core@5.60.6': {}
 
@@ -8568,14 +8578,6 @@ snapshots:
   negotiator@0.6.3: {}
 
   neo-async@2.6.2: {}
-
-  nestjs-redis-om@0.1.2(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.6)(redis-om@0.4.7)(reflect-metadata@0.2.2):
-    dependencies:
-      '@nestjs/common': 10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
-      '@nestjs/core': 10.4.6(@nestjs/common@10.4.6(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.6)(@nestjs/websockets@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
-      redis-om: 0.4.7
-      reflect-metadata: 0.2.2
-      uuid: 9.0.1
 
   node-abort-controller@3.1.1: {}
 


### PR DESCRIPTION
> - 작성자: 김찬우
> - 작성 날짜: 2024.11.27

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- `nestjs-redis-om` 모듈을 수정해서 오류를 해결했습니다.

## 📝 작업 상세 내역

### 패키지 출시

저 패키지 출시했어요. 축하해주세요.

[들어가보기](https://www.npmjs.com/package/@moozeh/nestjs-redis-om)

`MIT` 라이선스에 따라 원저자 출처를 해서 출시를 했습니다.

### 패키지 출시를 해야했던 이유

아래 `nestjs-redis-om` 코드를 수정할 필요가 있었습니다.

```ts
const schema = new Schema(
  entityMetadata.schemaName,
  entityMetadata.fields,
  entityMetadata.schemaOptions,
);
const repository = new Repository(schema, dataSource);
await repository.createIndex();
return repository;
```

이부분에서 인덱스 생성 시, 이미 존재하거나 상태가 동일하지 않을 경우 에러처리를 하지 않던 것이 문제였습니다.

실제로 `nestjs` 를 위한 `redis-om` 래퍼가 없었고, 다른 사람들도 불편함을 느꼈을 것으로 판단했습니다.

그래서 이왕 하는 김에 실제로 배포까지 진행했습니다. 추후에 `Schema` 기능 중에 `TTL` 설정하는 것까지 지원해볼 생각입니다.

## 💬 다음 작업 또는 논의 사항
- 스터디 기능을 위한 웹소켓 핸들러를 만들 생각입니다.

## 🐥 리뷰 받고 싶은 포인트
- 저 패키지 출시했어요 축하해줘요 🐥🐥