### PR TITLE
#260-1 [Feat] 유저 메타데이터 관련 API 추가

### DIFF
--- a/backend/src/user/dto/update-user.dto.ts
+++ b/backend/src/user/dto/update-user.dto.ts
@@ -1,0 +1,19 @@
+import { IsString, MaxLength } from "class-validator";
+import { User } from "@/user/user.entity";
+
+export interface ChangePassword {
+    original: string;
+    newPassword: string;
+}
+
+export class UpdateUserDto {
+    @IsString()
+    @MaxLength(User.USERNAME_MAX_LEN)
+    nickname?: string;
+
+    @IsString()
+    @MaxLength(User.URL_MAX_LEN)
+    avatarUrl?: string;
+
+    password?: ChangePassword;
+}

--- a/backend/src/user/dto/user.dto.ts
+++ b/backend/src/user/dto/user.dto.ts
@@ -1,7 +1,20 @@
 import { QuestionList } from "@/question-list/question-list.entity";
+import { LoginType } from "@/user/user.entity";
 
 export interface UserDto {
     loginId?: string;
+    loginType: LoginType;
+    passwordHash?: string;
+    githubId?: number;
+    username: string;
+    refreshToken: string;
+    scrappedQuestionLists: QuestionList[];
+}
+
+export interface UserInternalDto {
+    id: number;
+    loginId?: string;
+    loginType: LoginType;
     passwordHash?: string;
     githubId?: number;
     username: string;

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,0 +1,50 @@
+import {
+    Body,
+    Controller,
+    Get,
+    Param,
+    Patch,
+    Post,
+    UseGuards,
+    UsePipes,
+    ValidationPipe,
+} from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import { JwtPayload } from "@/auth/jwt/jwt.decorator";
+import { IJwtPayload } from "@/auth/jwt/jwt.model";
+import { UserRepository } from "@/user/user.repository";
+import { UpdateUserDto } from "@/user/dto/update-user.dto";
+import { UserService } from "@/user/user.service";
+import { CreateUserDto } from "@/user/dto/create-user.dto";
+
+@Controller("user")
+export class UserController {
+    constructor(
+        private readonly userRepository: UserRepository,
+        private readonly userService: UserService
+    ) {}
+
+    @Post("signup")
+    @UsePipes(ValidationPipe)
+    async handleSignup(@Body() dto: CreateUserDto) {
+        return this.userService.createUserByLocal(dto);
+    }
+
+    @Get("my")
+    @UseGuards(AuthGuard("jwt"))
+    async getMyInfo(@JwtPayload() payload: IJwtPayload) {
+        return this.userService.getChangeableUserInfo(payload.userId);
+    }
+
+    @Get(":userId")
+    @UsePipes(ValidationPipe)
+    async getUserInfo(@Param("userId") userId: number) {
+        return this.userService.getChangeableUserInfo(userId);
+    }
+
+    @Patch("my")
+    @UseGuards(AuthGuard("jwt"))
+    async changeMyInfo(@JwtPayload() payload: IJwtPayload, @Body() dto: UpdateUserDto) {
+        return this.userService.updateUserInfo(payload.userId, dto);
+    }
+}

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -1,11 +1,17 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToMany, JoinTable } from "typeorm";
+import { Column, Entity, JoinTable, ManyToMany, OneToMany, PrimaryGeneratedColumn } from "typeorm";
 import { QuestionList } from "@/question-list/question-list.entity";
+
+export enum LoginType {
+    LOCAL = "local",
+    GITHUB = "github",
+}
 
 @Entity()
 export class User {
+    public static readonly URL_MAX_LEN = 320;
+    public static readonly USERNAME_MAX_LEN = 20;
     private static LOGIN_ID_MAX_LEN = 20;
     private static PASSWORD_HASH_MAX_LEN = 256;
-    private static USERNAME_MAX_LEN = 20;
     private static REFRESH_TOKEN_MAX_LEN = 200;
 
     @PrimaryGeneratedColumn()
@@ -43,4 +49,14 @@ export class User {
         },
     })
     scrappedQuestionLists: QuestionList[];
+
+    @Column({
+        type: "enum",
+        enum: LoginType,
+        default: LoginType.LOCAL,
+    })
+    loginType: LoginType;
+
+    @Column({ length: User.URL_MAX_LEN, nullable: true })
+    avatarUrl: string;
 }

--- a/backend/src/user/user.repository.ts
+++ b/backend/src/user/user.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { User } from "./user.entity";
 import { DataSource } from "typeorm";
-import { CreateUserDto } from "./dto/create-user.dto";
+import { CreateUserInternalDto } from "./dto/create-user.dto";
 import { UserDto } from "./dto/user.dto";
 
 @Injectable()
@@ -24,7 +24,16 @@ export class UserRepository {
             .getOne();
     }
 
-    createUser(createUserDto: CreateUserDto) {
+    // TODO: 로그인 ID로 인덱싱 생성 필요?
+    getUserByLoginId(username: string) {
+        return this.dataSource
+            .getRepository(User)
+            .createQueryBuilder("user")
+            .where("user.login_id = :id", { id: username })
+            .getOne();
+    }
+
+    createUser(createUserDto: CreateUserInternalDto) {
         return this.dataSource.getRepository(User).save(createUserDto);
     }
 

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,0 +1,74 @@
+import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import { UserRepository } from "@/user/user.repository";
+import "dotenv/config";
+import { ChangePassword, UpdateUserDto } from "@/user/dto/update-user.dto";
+import { AuthService } from "@/auth/auth.service";
+import { Transactional } from "typeorm-transactional";
+import { LoginType, User } from "@/user/user.entity";
+import { CreateUserDto, CreateUserInternalDto } from "@/user/dto/create-user.dto";
+
+@Injectable()
+export class UserService {
+    constructor(
+        private readonly userRepository: UserRepository,
+        private readonly authService: AuthService
+    ) {}
+
+    public async getChangeableUserInfo(userId: number) {
+        const user = await this.userRepository.getUserByUserId(userId);
+        if (!user) throw new NotFoundException("User not found");
+        return {
+            userId: user.id,
+            nickname: user.username,
+            avatarUrl: user.avatarUrl,
+            loginType: user.loginType,
+        };
+    }
+
+    @Transactional()
+    public async updateUserInfo(userId: number, dto: UpdateUserDto) {
+        const user = await this.userRepository.getUserByUserId(userId);
+        if (!user) throw new BadRequestException("invalid user!");
+
+        const validPasswordDto =
+            dto.password &&
+            dto.password.original &&
+            dto.password.newPassword &&
+            user.loginType === LoginType.LOCAL;
+
+        user.avatarUrl = dto.avatarUrl || user.avatarUrl;
+        user.passwordHash = validPasswordDto
+            ? await this.changePassword(user, dto.password)
+            : user.passwordHash;
+        user.username = dto.nickname || user.username;
+
+        await this.userRepository.updateUser(user);
+        return dto;
+    }
+
+    @Transactional()
+    public async createUserByLocal(dto: CreateUserDto) {
+        const userDto: CreateUserInternalDto = {
+            loginId: dto.id,
+            loginType: LoginType.LOCAL,
+            username: dto.nickname,
+            passwordHash: this.authService.generatePasswordHash(dto.password),
+        };
+
+        await this.userRepository.createUser(userDto);
+
+        return {
+            status: "success",
+        };
+    }
+
+    @Transactional()
+    private async changePassword(user: User, pair: ChangePassword) {
+        const originalHash = this.authService.generatePasswordHash(pair.original);
+
+        if (originalHash !== user.passwordHash)
+            throw new BadRequestException("password does not match!");
+
+        return this.authService.generatePasswordHash(pair.newPassword);
+    }
+}


### PR DESCRIPTION


## 관련 이슈 번호
> - 작성자: 김찬우
> - 작성 날짜: 2024.11.28

- (이슈 번호 작성) # (작성예정)

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- 유저 수정 / 조회를 위한 DTO 추가
- 유저 아바타등록을 위한 엔티티에 아바타필드 추가 
- 유저 관련 비즈니스 로직 추가
- 유저 레포지토리 기능 추가

## 📝 작업 상세 내역

### 유저 수정 / 조회를 위한 DTO 추가, 유저 아바타 필드 추가

- 핸들러를 위한 DTO를 추가했습니다.
- 유저 엔티티에 아바타 필드를 추가했습니다.

### 유저 관련 비즈니스 로직 추가
- 비밀번호 변경
- 유저 메타 데이터 업데이트 기능
- 로컬로 로그인할 수 있도록 하는 회원가입 기능

### 유저 레포지토리 기능 추가
- 아이디로 엔티티 검색 가능한 기능을 추가했습니다!
- 추후 인덱싱해야하는데, 그냥 같은 PK로 둘지도 고민입니다.

## 📌 테스트 및 검증 결과
- POSTMAN으로 실행하였습니다.
- 수정, 인증, 조회 모두 가능합니다!

## 💬 다음 작업 또는 논의 사항

- 이 PR 다음 본 PR을 확인해주세요.

## 🐥 리뷰 받고 싶은 포인트

- 수민님 : 유저 엔티티 수정이 올바른지, 바뀐건 없는지 확인만 해주세요!
- 승윤님 : 원하는 명세대로 나왔는지, 더 원하시는 건 없는지 알려주세요!