### PR TITLE
#260-2 [Fix] 시간 정보 수정, JWT 토큰 만료 기간 버그 수정, 전략 패턴 수정 (#260 확인)

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,12 +1,10 @@
-import { Controller, Get, Post, Res, Req, UseGuards } from "@nestjs/common";
+import { Controller, Get, Post, Res, UseGuards } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
-import { Request, Response } from "express";
+import { Response } from "express";
 import { AuthService } from "./auth.service";
-import { GithubProfile } from "./github/gitub-profile.decorator";
-import { Profile } from "passport-github";
-import { setCookieConfig } from "../config/cookie.config";
+import { setCookieConfig } from "@/config/cookie.config";
 import { JwtPayload, JwtTokenPair } from "./jwt/jwt.decorator";
-import { IJwtPayload, IJwtTokenPair } from "./jwt/jwt.model";
+import { IJwtPayload, IJwtToken, IJwtTokenPair } from "./jwt/jwt.model";
 
 @Controller("auth")
 export class AuthController {
@@ -18,45 +16,44 @@ export class AuthController {
     @Post("github")
     @UseGuards(AuthGuard("github"))
     async githubCallback(
-        @Req() req: Request,
         @Res({ passthrough: true }) res: Response,
-        @GithubProfile() profile: Profile
+        @JwtTokenPair() pair: IJwtTokenPair
     ) {
-        const id = parseInt(profile.id);
-
-        const result = await this.authService.getTokenByGithubId(id);
-
-        res.cookie("accessToken", result.accessToken.token, {
-            maxAge: result.accessToken.expireTime,
-            ...setCookieConfig,
-        });
-
-        res.cookie("refreshToken", result.refreshToken.token, {
-            maxAge: result.refreshToken.expireTime,
-            ...setCookieConfig,
-        });
-
-        return {
-            success: true,
-        };
+        return this.setCookie(res, pair.accessToken, pair.refreshToken);
     }
 
     @Get("whoami")
     @UseGuards(AuthGuard("jwt"))
-    async handleWhoami(@Req() req: Request, @JwtPayload() token: IJwtPayload) {
-        return token;
+    async handleWhoami(@JwtPayload() payload: IJwtPayload) {
+        return payload;
     }
 
     @Get("refresh")
     @UseGuards(AuthGuard("jwt-refresh"))
     async handleRefresh(
         @Res({ passthrough: true }) res: Response,
-        @JwtTokenPair() token: IJwtTokenPair
+        @JwtTokenPair() pair: IJwtTokenPair
     ) {
-        res.cookie("accessToken", token.accessToken.token, {
-            maxAge: token.accessToken.expireTime,
+        return this.setCookie(res, pair.accessToken);
+    }
+
+    @Post("login")
+    @UseGuards(AuthGuard("local"))
+    async login(@Res({ passthrough: true }) res: Response, @JwtTokenPair() pair: IJwtTokenPair) {
+        return this.setCookie(res, pair.accessToken, pair.refreshToken);
+    }
+
+    private setCookie(res: Response, accessToken: IJwtToken, refreshToken?: IJwtToken) {
+        res.cookie("accessToken", accessToken.token, {
+            maxAge: accessToken.expireTime,
             ...setCookieConfig,
         });
+
+        if (refreshToken)
+            res.cookie("refreshToken", refreshToken.token, {
+                maxAge: refreshToken.expireTime,
+                ...setCookieConfig,
+            });
 
         return {
             success: true,

--- a/backend/src/auth/github/github.strategy.ts
+++ b/backend/src/auth/github/github.strategy.ts
@@ -5,47 +5,59 @@ import { Strategy } from "passport-custom";
 import { Request } from "express";
 import axios from "axios";
 import "dotenv/config";
+import { AuthService } from "@/auth/auth.service";
+import { JwtService } from "@/auth/jwt/jwt.service";
 
 @Injectable()
 export class GithubStrategy extends PassportStrategy(Strategy, "github") {
-    private static REQUEST_ACCESS_TOKEN_URL =
-        "https://github.com/login/oauth/access_token";
+    private static REQUEST_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
     private static REQUEST_USER_URL = "https://api.github.com/user";
 
-    constructor() {
+    constructor(
+        private readonly authService: AuthService,
+        private readonly jwtService: JwtService
+    ) {
         super();
     }
 
-    async validate(req: Request, done: any) {
+    async validate(req: Request) {
         const { code } = req.body;
 
         if (!code) {
             throw new UnauthorizedException("Authorization code not found");
         }
 
-        const tokenResponse = await axios.post(
+        const { access_token: accessToken } = (await this.fetchAccessToken(code)).data;
+
+        const profile = (await this.fetchGithubUser(accessToken)).data;
+
+        const user = await this.authService.getUserByGithubId(profile.id);
+        const token = await this.jwtService.createJwtToken(user);
+
+        return {
+            jwtToken: token,
+        };
+    }
+
+    private async fetchAccessToken(code: string) {
+        return axios.post(
             GithubStrategy.REQUEST_ACCESS_TOKEN_URL,
             {
                 client_id: process.env.OAUTH_GITHUB_ID,
                 client_secret: process.env.OAUTH_GITHUB_SECRET,
-                code: code,
+                code,
             },
             {
                 headers: { Accept: "application/json" },
             }
         );
+    }
 
-        const { access_token } = tokenResponse.data;
-
-        // GitHub 사용자 정보 조회
-        const userResponse = await axios.get(GithubStrategy.REQUEST_USER_URL, {
+    private async fetchGithubUser(accessToken: string) {
+        return axios.get(GithubStrategy.REQUEST_USER_URL, {
             headers: {
-                Authorization: `Bearer ${access_token}`,
+                Authorization: `Bearer ${accessToken}`,
             },
-        });
-
-        return done(null, {
-            profile: userResponse.data,
         });
     }
 }

--- a/backend/src/auth/jwt/jwt.decorator.ts
+++ b/backend/src/auth/jwt/jwt.decorator.ts
@@ -6,55 +6,42 @@ import {
 } from "@nestjs/common";
 import {
     IJwtPayload as IJwtPayload,
-    IJwtTokenPair as IJwtTokenPair,
     IJwtToken as IJwtToken,
+    IJwtTokenPair as IJwtTokenPair,
 } from "./jwt.model";
 
-export const JwtPayload = createParamDecorator(
-    (data: unknown, ctx: ExecutionContext) => {
-        const request = ctx.switchToHttp().getRequest();
-        const payload = request.user.jwtToken;
+export const JwtPayload = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    const payload = request.user.jwtToken;
 
-        if (!isJwtTokenPayload(payload)) {
-            throw new UnauthorizedException("Invalid jwt token payload");
-        }
-
-        return payload;
+    if (!isJwtTokenPayload(payload)) {
+        throw new UnauthorizedException("Invalid jwt token payload");
     }
-);
 
-export const JwtTokenPair = createParamDecorator(
-    (data: unknown, ctx: ExecutionContext) => {
-        const request = ctx.switchToHttp().getRequest();
-        const payload = request.user.jwtToken;
+    return payload;
+});
 
-        if (!isJwtTokenPair(payload)) {
-            throw new InternalServerErrorException("Invalid jwt token");
-        }
+export const JwtTokenPair = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    const payload = request.user.jwtToken;
 
-        return payload;
+    if (!isJwtTokenPair(payload)) {
+        throw new InternalServerErrorException("Invalid jwt token");
     }
-);
+
+    return payload;
+});
 
 function isJwtTokenPayload(payload: any): payload is IJwtPayload {
-    return (
-        payload &&
-        typeof payload.userId === "number" &&
-        typeof payload.username === "string"
-    );
+    return payload && typeof payload.userId === "number" && typeof payload.username === "string";
 }
 
 function isJwtTokenPair(payload: any): payload is IJwtTokenPair {
     if (!payload.accessToken || !payload.refreshToken) return false;
     if (!isJwtToken(payload.accessToken)) return false;
-    if (!isJwtToken(payload.refreshToken)) return false;
-    return true;
+    return isJwtToken(payload.refreshToken);
 }
 
 function isJwtToken(token: any): token is IJwtToken {
-    return (
-        token &&
-        typeof token.token === "string" &&
-        typeof token.expireTime === "number"
-    );
+    return token && typeof token.token === "string" && typeof token.expireTime === "number";
 }

--- a/backend/src/auth/jwt/strategy/refresh-token.strategy.ts
+++ b/backend/src/auth/jwt/strategy/refresh-token.strategy.ts
@@ -6,10 +6,7 @@ import "dotenv/config";
 import { JwtService } from "../jwt.service";
 
 @Injectable()
-export class RefreshTokenStrategy extends PassportStrategy(
-    Strategy,
-    "jwt-refresh"
-) {
+export class RefreshTokenStrategy extends PassportStrategy(Strategy, "jwt-refresh") {
     constructor(private readonly jwtService: JwtService) {
         super({
             jwtFromRequest: (req: Request) => {
@@ -26,10 +23,7 @@ export class RefreshTokenStrategy extends PassportStrategy(
         const { aud, exp } = payload;
         const refreshToken = req.cookies["refreshToken"];
 
-        const accessToken = await this.jwtService.getNewAccessToken(
-            parseInt(aud),
-            refreshToken
-        );
+        const accessToken = await this.jwtService.getNewAccessToken(parseInt(aud), refreshToken);
 
         return {
             jwtToken: {

--- a/backend/src/user/dto/update-user.dto.ts
+++ b/backend/src/user/dto/update-user.dto.ts
@@ -1,0 +1,19 @@
+import { IsString, MaxLength } from "class-validator";
+import { User } from "@/user/user.entity";
+
+export interface ChangePassword {
+    original: string;
+    newPassword: string;
+}
+
+export class UpdateUserDto {
+    @IsString()
+    @MaxLength(User.USERNAME_MAX_LEN)
+    nickname?: string;
+
+    @IsString()
+    @MaxLength(User.URL_MAX_LEN)
+    avatarUrl?: string;
+
+    password?: ChangePassword;
+}

--- a/backend/src/user/dto/user.dto.ts
+++ b/backend/src/user/dto/user.dto.ts
@@ -1,7 +1,20 @@
 import { QuestionList } from "@/question-list/question-list.entity";
+import { LoginType } from "@/user/user.entity";
 
 export interface UserDto {
     loginId?: string;
+    loginType: LoginType;
+    passwordHash?: string;
+    githubId?: number;
+    username: string;
+    refreshToken: string;
+    scrappedQuestionLists: QuestionList[];
+}
+
+export interface UserInternalDto {
+    id: number;
+    loginId?: string;
+    loginType: LoginType;
     passwordHash?: string;
     githubId?: number;
     username: string;

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,0 +1,50 @@
+import {
+    Body,
+    Controller,
+    Get,
+    Param,
+    Patch,
+    Post,
+    UseGuards,
+    UsePipes,
+    ValidationPipe,
+} from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import { JwtPayload } from "@/auth/jwt/jwt.decorator";
+import { IJwtPayload } from "@/auth/jwt/jwt.model";
+import { UserRepository } from "@/user/user.repository";
+import { UpdateUserDto } from "@/user/dto/update-user.dto";
+import { UserService } from "@/user/user.service";
+import { CreateUserDto } from "@/user/dto/create-user.dto";
+
+@Controller("user")
+export class UserController {
+    constructor(
+        private readonly userRepository: UserRepository,
+        private readonly userService: UserService
+    ) {}
+
+    @Post("signup")
+    @UsePipes(ValidationPipe)
+    async handleSignup(@Body() dto: CreateUserDto) {
+        return this.userService.createUserByLocal(dto);
+    }
+
+    @Get("my")
+    @UseGuards(AuthGuard("jwt"))
+    async getMyInfo(@JwtPayload() payload: IJwtPayload) {
+        return this.userService.getChangeableUserInfo(payload.userId);
+    }
+
+    @Get(":userId")
+    @UsePipes(ValidationPipe)
+    async getUserInfo(@Param("userId") userId: number) {
+        return this.userService.getChangeableUserInfo(userId);
+    }
+
+    @Patch("my")
+    @UseGuards(AuthGuard("jwt"))
+    async changeMyInfo(@JwtPayload() payload: IJwtPayload, @Body() dto: UpdateUserDto) {
+        return this.userService.updateUserInfo(payload.userId, dto);
+    }
+}

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -1,11 +1,17 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToMany, JoinTable } from "typeorm";
+import { Column, Entity, JoinTable, ManyToMany, OneToMany, PrimaryGeneratedColumn } from "typeorm";
 import { QuestionList } from "@/question-list/question-list.entity";
+
+export enum LoginType {
+    LOCAL = "local",
+    GITHUB = "github",
+}
 
 @Entity()
 export class User {
+    public static readonly URL_MAX_LEN = 320;
+    public static readonly USERNAME_MAX_LEN = 20;
     private static LOGIN_ID_MAX_LEN = 20;
     private static PASSWORD_HASH_MAX_LEN = 256;
-    private static USERNAME_MAX_LEN = 20;
     private static REFRESH_TOKEN_MAX_LEN = 200;
 
     @PrimaryGeneratedColumn()
@@ -43,4 +49,14 @@ export class User {
         },
     })
     scrappedQuestionLists: QuestionList[];
+
+    @Column({
+        type: "enum",
+        enum: LoginType,
+        default: LoginType.LOCAL,
+    })
+    loginType: LoginType;
+
+    @Column({ length: User.URL_MAX_LEN, nullable: true })
+    avatarUrl: string;
 }

--- a/backend/src/user/user.repository.ts
+++ b/backend/src/user/user.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { User } from "./user.entity";
 import { DataSource } from "typeorm";
-import { CreateUserDto } from "./dto/create-user.dto";
+import { CreateUserInternalDto } from "./dto/create-user.dto";
 import { UserDto } from "./dto/user.dto";
 
 @Injectable()
@@ -24,7 +24,16 @@ export class UserRepository {
             .getOne();
     }
 
-    createUser(createUserDto: CreateUserDto) {
+    // TODO: 로그인 ID로 인덱싱 생성 필요?
+    getUserByLoginId(username: string) {
+        return this.dataSource
+            .getRepository(User)
+            .createQueryBuilder("user")
+            .where("user.login_id = :id", { id: username })
+            .getOne();
+    }
+
+    createUser(createUserDto: CreateUserInternalDto) {
         return this.dataSource.getRepository(User).save(createUserDto);
     }
 

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,0 +1,74 @@
+import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import { UserRepository } from "@/user/user.repository";
+import "dotenv/config";
+import { ChangePassword, UpdateUserDto } from "@/user/dto/update-user.dto";
+import { AuthService } from "@/auth/auth.service";
+import { Transactional } from "typeorm-transactional";
+import { LoginType, User } from "@/user/user.entity";
+import { CreateUserDto, CreateUserInternalDto } from "@/user/dto/create-user.dto";
+
+@Injectable()
+export class UserService {
+    constructor(
+        private readonly userRepository: UserRepository,
+        private readonly authService: AuthService
+    ) {}
+
+    public async getChangeableUserInfo(userId: number) {
+        const user = await this.userRepository.getUserByUserId(userId);
+        if (!user) throw new NotFoundException("User not found");
+        return {
+            userId: user.id,
+            nickname: user.username,
+            avatarUrl: user.avatarUrl,
+            loginType: user.loginType,
+        };
+    }
+
+    @Transactional()
+    public async updateUserInfo(userId: number, dto: UpdateUserDto) {
+        const user = await this.userRepository.getUserByUserId(userId);
+        if (!user) throw new BadRequestException("invalid user!");
+
+        const validPasswordDto =
+            dto.password &&
+            dto.password.original &&
+            dto.password.newPassword &&
+            user.loginType === LoginType.LOCAL;
+
+        user.avatarUrl = dto.avatarUrl || user.avatarUrl;
+        user.passwordHash = validPasswordDto
+            ? await this.changePassword(user, dto.password)
+            : user.passwordHash;
+        user.username = dto.nickname || user.username;
+
+        await this.userRepository.updateUser(user);
+        return dto;
+    }
+
+    @Transactional()
+    public async createUserByLocal(dto: CreateUserDto) {
+        const userDto: CreateUserInternalDto = {
+            loginId: dto.id,
+            loginType: LoginType.LOCAL,
+            username: dto.nickname,
+            passwordHash: this.authService.generatePasswordHash(dto.password),
+        };
+
+        await this.userRepository.createUser(userDto);
+
+        return {
+            status: "success",
+        };
+    }
+
+    @Transactional()
+    private async changePassword(user: User, pair: ChangePassword) {
+        const originalHash = this.authService.generatePasswordHash(pair.original);
+
+        if (originalHash !== user.passwordHash)
+            throw new BadRequestException("password does not match!");
+
+        return this.authService.generatePasswordHash(pair.newPassword);
+    }
+}

--- a/backend/src/utils/time.ts
+++ b/backend/src/utils/time.ts
@@ -1,4 +1,4 @@
-export const SEC = 1;
+export const SEC = 1000;
 export const MIN = 60 * SEC;
 export const HOUR = 60 * MIN;
 export const DAY = 24 * HOUR;


### PR DESCRIPTION
> [!note]
>
> 한꺼번에 많은 PR을 올리지 않도록 분리하였습니다.
> #260
> 을 먼저 확인해주세요. 이 PR과 연관되어있어서 이 PR 이 머지되면 저곳도 머지 됩니다.

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- 시간 정보 수정
- JWT 토큰 만료 기간 버그 수정
- 전략 패턴 수정

## 📝 작업 상세 내역

지금 보여주는 코드는 이전 코드 입니다!

### 시간 정보 수정

- 1초는 1000 밀리 세컨드 ..

```ts
// utils/time.ts
export const SEC = 1; // ?????? 
export const MIN = 60 * SEC;
export const HOUR = 60 * MIN;
export const DAY = 24 * HOUR;
```

### JWT 토큰 만료 기간 버그 수정

- JWT 토큰 설정 시, 설정 시간이 잘못되어있었습니다.
- 만료 기간을 설정해야하는데, 만료 시간으로 설정하였습니다.
- 그렇게돼서 무려 만료시간이 1년 뒤.. 로 설정되는 버그가 있었고, 해결했습니다.

```ts
// jwt.service.ts
 public async createAccessToken(user: User): Promise<IJwtToken> {
        const accessToken = this.parent.sign(
            {
                userId: user.id,
                username: user.username,
            },
            {
                secret: process.env.JWT_ACCESS_TOKEN_SECRET_KEY,
                expiresIn: process.env.JWT_ACCESS_TOKEN_EXPIRATION_TIME,
            }
        );

        return {
            token: accessToken,
            expireTime: Date.now() + JwtService.ACCESS_TOKEN_TIME, // 해당 부분에 버그가 있었음
        };
    }
```

### 전략 패턴 수정
- `인증`까지만 범위 설정을 어떻게 할지 고민을 많이 했음
- 인증에 성공했다면, 토큰을 받아오도록 통일해야하지 않을까? 라는 생각을 하게 됨
- 그렇게 전략 패턴별로 토큰을 반환하도록 통일함
- GithubProfile 이라는 정보도 나중에 삭제할 예정

```ts
// github-auth.strategy.ts
import { Injectable, UnauthorizedException } from "@nestjs/common";
import { PassportStrategy } from "@nestjs/passport";
import { Strategy } from "passport-custom";
import { Request } from "express";
import axios from "axios";
import "dotenv/config";

@Injectable()
export class GithubStrategy extends PassportStrategy(Strategy, "github") {
    private static REQUEST_ACCESS_TOKEN_URL =
        "https://github.com/login/oauth/access_token";
    private static REQUEST_USER_URL = "https://api.github.com/user";

    constructor() {
        super();
    }

    async validate(req: Request, done: any) {
        const { code } = req.body;

        if (!code) {
            throw new UnauthorizedException("Authorization code not found");
        }

        const tokenResponse = await axios.post(
            GithubStrategy.REQUEST_ACCESS_TOKEN_URL,
            {
                client_id: process.env.OAUTH_GITHUB_ID,
                client_secret: process.env.OAUTH_GITHUB_SECRET,
                code: code,
            },
            {
                headers: { Accept: "application/json" },
            }
        );

        const { access_token } = tokenResponse.data;

        // GitHub 사용자 정보 조회
        const userResponse = await axios.get(GithubStrategy.REQUEST_USER_URL, {
            headers: {
                Authorization: `Bearer ${access_token}`,
            },
        });

        return done(null, {
            profile: userResponse.data, // 여기서 끝내지 말고, 그냥 로컬 토큰을 넘겨주는게 어떨까?
        });
    }
}

```

## 📌 테스트 및 검증 결과
- 직접 프론트에서 테스트 했음
- 로그인 성공과, 토큰 기간 확인 했습니다.

## 💬 다음 작업 또는 논의 사항
- 로컬 로그인 / 회원가입 기능을 추가했습니다.