### PR TITLE
#260-3 [Feat] 로그인 / 회원가입 기능 구현

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,12 +1,10 @@
-import { Controller, Get, Post, Res, Req, UseGuards } from "@nestjs/common";
+import { Controller, Get, Post, Res, UseGuards } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
-import { Request, Response } from "express";
+import { Response } from "express";
 import { AuthService } from "./auth.service";
-import { GithubProfile } from "./github/gitub-profile.decorator";
-import { Profile } from "passport-github";
-import { setCookieConfig } from "../config/cookie.config";
+import { setCookieConfig } from "@/config/cookie.config";
 import { JwtPayload, JwtTokenPair } from "./jwt/jwt.decorator";
-import { IJwtPayload, IJwtTokenPair } from "./jwt/jwt.model";
+import { IJwtPayload, IJwtToken, IJwtTokenPair } from "./jwt/jwt.model";
 
 @Controller("auth")
 export class AuthController {
@@ -18,45 +16,44 @@ export class AuthController {
     @Post("github")
     @UseGuards(AuthGuard("github"))
     async githubCallback(
-        @Req() req: Request,
         @Res({ passthrough: true }) res: Response,
-        @GithubProfile() profile: Profile
+        @JwtTokenPair() pair: IJwtTokenPair
     ) {
-        const id = parseInt(profile.id);
-
-        const result = await this.authService.getTokenByGithubId(id);
-
-        res.cookie("accessToken", result.accessToken.token, {
-            maxAge: result.accessToken.expireTime,
-            ...setCookieConfig,
-        });
-
-        res.cookie("refreshToken", result.refreshToken.token, {
-            maxAge: result.refreshToken.expireTime,
-            ...setCookieConfig,
-        });
-
-        return {
-            success: true,
-        };
+        return this.setCookie(res, pair.accessToken, pair.refreshToken);
     }
 
     @Get("whoami")
     @UseGuards(AuthGuard("jwt"))
-    async handleWhoami(@Req() req: Request, @JwtPayload() token: IJwtPayload) {
-        return token;
+    async handleWhoami(@JwtPayload() payload: IJwtPayload) {
+        return payload;
     }
 
     @Get("refresh")
     @UseGuards(AuthGuard("jwt-refresh"))
     async handleRefresh(
         @Res({ passthrough: true }) res: Response,
-        @JwtTokenPair() token: IJwtTokenPair
+        @JwtTokenPair() pair: IJwtTokenPair
     ) {
-        res.cookie("accessToken", token.accessToken.token, {
-            maxAge: token.accessToken.expireTime,
+        return this.setCookie(res, pair.accessToken);
+    }
+
+    @Post("login")
+    @UseGuards(AuthGuard("local"))
+    async login(@Res({ passthrough: true }) res: Response, @JwtTokenPair() pair: IJwtTokenPair) {
+        return this.setCookie(res, pair.accessToken, pair.refreshToken);
+    }
+
+    private setCookie(res: Response, accessToken: IJwtToken, refreshToken?: IJwtToken) {
+        res.cookie("accessToken", accessToken.token, {
+            maxAge: accessToken.expireTime,
             ...setCookieConfig,
         });
+
+        if (refreshToken)
+            res.cookie("refreshToken", refreshToken.token, {
+                maxAge: refreshToken.expireTime,
+                ...setCookieConfig,
+            });
 
         return {
             success: true,

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -2,12 +2,14 @@ import { Module } from "@nestjs/common";
 import { AuthController } from "./auth.controller";
 import { AuthService } from "./auth.service";
 import { GithubStrategy } from "./github/github.strategy";
-import { UserRepository } from "../user/user.repository";
+import { UserRepository } from "@/user/user.repository";
 import { JwtModule } from "./jwt/jwt.module";
+import { LocalStrategy } from "@/auth/local/local.strategy";
+import { UserService } from "@/user/user.service";
 
 @Module({
     imports: [JwtModule],
     controllers: [AuthController],
-    providers: [AuthService, GithubStrategy, UserRepository],
+    providers: [AuthService, GithubStrategy, LocalStrategy, UserRepository, UserService],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,14 +1,14 @@
-import { Injectable, UnauthorizedException } from "@nestjs/common";
-import { UserRepository } from "../user/user.repository";
+import { Injectable } from "@nestjs/common";
+import { UserRepository } from "@/user/user.repository";
 import { Transactional } from "typeorm-transactional";
 import "dotenv/config";
-import { DAY, HOUR } from "../utils/time";
 import { JwtService } from "./jwt/jwt.service";
+import { LoginType } from "@/user/user.entity";
+import { createHash } from "node:crypto";
 
 @Injectable()
 export class AuthService {
-    private static ACCESS_TOKEN_EXPIRATION_TIME = 3 * HOUR;
-    private static ACCESS_TOKEN_EXPIRATION = 30 * DAY;
+    private static PASSWORD_SALT = process.env.PASSWORD_SALT;
 
     constructor(
         private readonly userRepository: UserRepository,
@@ -16,16 +16,30 @@ export class AuthService {
     ) {}
 
     @Transactional()
-    public async getTokenByGithubId(id: number) {
+    public async getUserByGithubId(id: number) {
         let user = await this.userRepository.getUserByGithubId(id);
 
-        if (!user) {
+        if (!user)
             user = await this.userRepository.createUser({
                 githubId: id,
                 username: `camper_${id}`,
+                loginType: LoginType.GITHUB,
             });
-        }
 
-        return await this.jwtService.createJwtToken(user.id);
+        return user;
+    }
+
+    public async getUserByLocal(username: string, password: string) {
+        const user = await this.userRepository.getUserByLoginId(username);
+        if (!user) return null;
+        if (user.passwordHash !== this.generatePasswordHash(password)) return null;
+
+        return user;
+    }
+
+    public generatePasswordHash(password: string) {
+        return createHash("sha256")
+            .update(password + process.env.SESSION_HASH)
+            .digest("hex");
     }
 }

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,0 +1,12 @@
+import { IsNotEmpty, IsString } from "class-validator";
+
+// TODO: 프론트에서 정의된 제약사항 이곳에서도 검증하도록 보완하기
+export class LoginDto {
+    @IsString()
+    @IsNotEmpty()
+    userId: string;
+
+    @IsString()
+    @IsNotEmpty()
+    password: string;
+}

--- a/backend/src/auth/github/github.strategy.ts
+++ b/backend/src/auth/github/github.strategy.ts
@@ -5,47 +5,59 @@ import { Strategy } from "passport-custom";
 import { Request } from "express";
 import axios from "axios";
 import "dotenv/config";
+import { AuthService } from "@/auth/auth.service";
+import { JwtService } from "@/auth/jwt/jwt.service";
 
 @Injectable()
 export class GithubStrategy extends PassportStrategy(Strategy, "github") {
-    private static REQUEST_ACCESS_TOKEN_URL =
-        "https://github.com/login/oauth/access_token";
+    private static REQUEST_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
     private static REQUEST_USER_URL = "https://api.github.com/user";
 
-    constructor() {
+    constructor(
+        private readonly authService: AuthService,
+        private readonly jwtService: JwtService
+    ) {
         super();
     }
 
-    async validate(req: Request, done: any) {
+    async validate(req: Request) {
         const { code } = req.body;
 
         if (!code) {
             throw new UnauthorizedException("Authorization code not found");
         }
 
-        const tokenResponse = await axios.post(
+        const { access_token: accessToken } = (await this.fetchAccessToken(code)).data;
+
+        const profile = (await this.fetchGithubUser(accessToken)).data;
+
+        const user = await this.authService.getUserByGithubId(profile.id);
+        const token = await this.jwtService.createJwtToken(user);
+
+        return {
+            jwtToken: token,
+        };
+    }
+
+    private async fetchAccessToken(code: string) {
+        return axios.post(
             GithubStrategy.REQUEST_ACCESS_TOKEN_URL,
             {
                 client_id: process.env.OAUTH_GITHUB_ID,
                 client_secret: process.env.OAUTH_GITHUB_SECRET,
-                code: code,
+                code,
             },
             {
                 headers: { Accept: "application/json" },
             }
         );
+    }
 
-        const { access_token } = tokenResponse.data;
-
-        // GitHub 사용자 정보 조회
-        const userResponse = await axios.get(GithubStrategy.REQUEST_USER_URL, {
+    private async fetchGithubUser(accessToken: string) {
+        return axios.get(GithubStrategy.REQUEST_USER_URL, {
             headers: {
-                Authorization: `Bearer ${access_token}`,
+                Authorization: `Bearer ${accessToken}`,
             },
-        });
-
-        return done(null, {
-            profile: userResponse.data,
         });
     }
 }

--- a/backend/src/auth/jwt/jwt.decorator.ts
+++ b/backend/src/auth/jwt/jwt.decorator.ts
@@ -6,55 +6,42 @@ import {
 } from "@nestjs/common";
 import {
     IJwtPayload as IJwtPayload,
-    IJwtTokenPair as IJwtTokenPair,
     IJwtToken as IJwtToken,
+    IJwtTokenPair as IJwtTokenPair,
 } from "./jwt.model";
 
-export const JwtPayload = createParamDecorator(
-    (data: unknown, ctx: ExecutionContext) => {
-        const request = ctx.switchToHttp().getRequest();
-        const payload = request.user.jwtToken;
+export const JwtPayload = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    const payload = request.user.jwtToken;
 
-        if (!isJwtTokenPayload(payload)) {
-            throw new UnauthorizedException("Invalid jwt token payload");
-        }
-
-        return payload;
+    if (!isJwtTokenPayload(payload)) {
+        throw new UnauthorizedException("Invalid jwt token payload");
     }
-);
 
-export const JwtTokenPair = createParamDecorator(
-    (data: unknown, ctx: ExecutionContext) => {
-        const request = ctx.switchToHttp().getRequest();
-        const payload = request.user.jwtToken;
+    return payload;
+});
 
-        if (!isJwtTokenPair(payload)) {
-            throw new InternalServerErrorException("Invalid jwt token");
-        }
+export const JwtTokenPair = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    const payload = request.user.jwtToken;
 
-        return payload;
+    if (!isJwtTokenPair(payload)) {
+        throw new InternalServerErrorException("Invalid jwt token");
     }
-);
+
+    return payload;
+});
 
 function isJwtTokenPayload(payload: any): payload is IJwtPayload {
-    return (
-        payload &&
-        typeof payload.userId === "number" &&
-        typeof payload.username === "string"
-    );
+    return payload && typeof payload.userId === "number" && typeof payload.username === "string";
 }
 
 function isJwtTokenPair(payload: any): payload is IJwtTokenPair {
     if (!payload.accessToken || !payload.refreshToken) return false;
     if (!isJwtToken(payload.accessToken)) return false;
-    if (!isJwtToken(payload.refreshToken)) return false;
-    return true;
+    return isJwtToken(payload.refreshToken);
 }
 
 function isJwtToken(token: any): token is IJwtToken {
-    return (
-        token &&
-        typeof token.token === "string" &&
-        typeof token.expireTime === "number"
-    );
+    return token && typeof token.token === "string" && typeof token.expireTime === "number";
 }

--- a/backend/src/auth/jwt/strategy/refresh-token.strategy.ts
+++ b/backend/src/auth/jwt/strategy/refresh-token.strategy.ts
@@ -6,10 +6,7 @@ import "dotenv/config";
 import { JwtService } from "../jwt.service";
 
 @Injectable()
-export class RefreshTokenStrategy extends PassportStrategy(
-    Strategy,
-    "jwt-refresh"
-) {
+export class RefreshTokenStrategy extends PassportStrategy(Strategy, "jwt-refresh") {
     constructor(private readonly jwtService: JwtService) {
         super({
             jwtFromRequest: (req: Request) => {
@@ -26,10 +23,7 @@ export class RefreshTokenStrategy extends PassportStrategy(
         const { aud, exp } = payload;
         const refreshToken = req.cookies["refreshToken"];
 
-        const accessToken = await this.jwtService.getNewAccessToken(
-            parseInt(aud),
-            refreshToken
-        );
+        const accessToken = await this.jwtService.getNewAccessToken(parseInt(aud), refreshToken);
 
         return {
             jwtToken: {

--- a/backend/src/auth/local/local.strategy.ts
+++ b/backend/src/auth/local/local.strategy.ts
@@ -1,0 +1,29 @@
+import { Strategy } from "passport-local";
+import { PassportStrategy } from "@nestjs/passport";
+import { Injectable, UnauthorizedException } from "@nestjs/common";
+import { JwtService } from "@/auth/jwt/jwt.service";
+import { AuthService } from "@/auth/auth.service";
+
+@Injectable()
+export class LocalStrategy extends PassportStrategy(Strategy) {
+    constructor(
+        private readonly authService: AuthService,
+        private readonly jwtService: JwtService
+    ) {
+        super({
+            usernameField: "userId",
+            passwordField: "password",
+        });
+    }
+
+    async validate(username: string, password: string): Promise<any> {
+        const user = await this.authService.getUserByLocal(username, password);
+
+        if (!user) throw new UnauthorizedException("Invalid User login!");
+        const token = await this.jwtService.createJwtToken(user);
+
+        return {
+            jwtToken: token,
+        };
+    }
+}

--- a/backend/src/config/cookie.config.ts
+++ b/backend/src/config/cookie.config.ts
@@ -1,4 +1,6 @@
+import "dotenv/config";
+
 export const setCookieConfig = {
     httpOnly: true,
-    secure: true,
+    secure: process.env.NODE_ENV === "production",
 };

--- a/backend/src/user/dto/create-user.dto.ts
+++ b/backend/src/user/dto/create-user.dto.ts
@@ -1,6 +1,21 @@
-export interface CreateUserDto {
+import { LoginType } from "@/user/user.entity";
+import { IsNotEmpty } from "class-validator";
+
+export class CreateUserDto {
+    @IsNotEmpty()
+    id: string;
+
+    @IsNotEmpty()
+    password: string;
+
+    @IsNotEmpty()
+    nickname: string;
+}
+
+export interface CreateUserInternalDto {
     loginId?: string;
     passwordHash?: string;
     githubId?: number;
     username: string;
+    loginType: LoginType;
 }

--- a/backend/src/user/dto/update-user.dto.ts
+++ b/backend/src/user/dto/update-user.dto.ts
@@ -1,0 +1,19 @@
+import { IsString, MaxLength } from "class-validator";
+import { User } from "@/user/user.entity";
+
+export interface ChangePassword {
+    original: string;
+    newPassword: string;
+}
+
+export class UpdateUserDto {
+    @IsString()
+    @MaxLength(User.USERNAME_MAX_LEN)
+    nickname?: string;
+
+    @IsString()
+    @MaxLength(User.URL_MAX_LEN)
+    avatarUrl?: string;
+
+    password?: ChangePassword;
+}

--- a/backend/src/user/dto/user.dto.ts
+++ b/backend/src/user/dto/user.dto.ts
@@ -1,7 +1,20 @@
 import { QuestionList } from "@/question-list/question-list.entity";
+import { LoginType } from "@/user/user.entity";
 
 export interface UserDto {
     loginId?: string;
+    loginType: LoginType;
+    passwordHash?: string;
+    githubId?: number;
+    username: string;
+    refreshToken: string;
+    scrappedQuestionLists: QuestionList[];
+}
+
+export interface UserInternalDto {
+    id: number;
+    loginId?: string;
+    loginType: LoginType;
     passwordHash?: string;
     githubId?: number;
     username: string;

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -1,0 +1,50 @@
+import {
+    Body,
+    Controller,
+    Get,
+    Param,
+    Patch,
+    Post,
+    UseGuards,
+    UsePipes,
+    ValidationPipe,
+} from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import { JwtPayload } from "@/auth/jwt/jwt.decorator";
+import { IJwtPayload } from "@/auth/jwt/jwt.model";
+import { UserRepository } from "@/user/user.repository";
+import { UpdateUserDto } from "@/user/dto/update-user.dto";
+import { UserService } from "@/user/user.service";
+import { CreateUserDto } from "@/user/dto/create-user.dto";
+
+@Controller("user")
+export class UserController {
+    constructor(
+        private readonly userRepository: UserRepository,
+        private readonly userService: UserService
+    ) {}
+
+    @Post("signup")
+    @UsePipes(ValidationPipe)
+    async handleSignup(@Body() dto: CreateUserDto) {
+        return this.userService.createUserByLocal(dto);
+    }
+
+    @Get("my")
+    @UseGuards(AuthGuard("jwt"))
+    async getMyInfo(@JwtPayload() payload: IJwtPayload) {
+        return this.userService.getChangeableUserInfo(payload.userId);
+    }
+
+    @Get(":userId")
+    @UsePipes(ValidationPipe)
+    async getUserInfo(@Param("userId") userId: number) {
+        return this.userService.getChangeableUserInfo(userId);
+    }
+
+    @Patch("my")
+    @UseGuards(AuthGuard("jwt"))
+    async changeMyInfo(@JwtPayload() payload: IJwtPayload, @Body() dto: UpdateUserDto) {
+        return this.userService.updateUserInfo(payload.userId, dto);
+    }
+}

--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -1,11 +1,17 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToMany, JoinTable } from "typeorm";
+import { Column, Entity, JoinTable, ManyToMany, OneToMany, PrimaryGeneratedColumn } from "typeorm";
 import { QuestionList } from "@/question-list/question-list.entity";
+
+export enum LoginType {
+    LOCAL = "local",
+    GITHUB = "github",
+}
 
 @Entity()
 export class User {
+    public static readonly URL_MAX_LEN = 320;
+    public static readonly USERNAME_MAX_LEN = 20;
     private static LOGIN_ID_MAX_LEN = 20;
     private static PASSWORD_HASH_MAX_LEN = 256;
-    private static USERNAME_MAX_LEN = 20;
     private static REFRESH_TOKEN_MAX_LEN = 200;
 
     @PrimaryGeneratedColumn()
@@ -43,4 +49,14 @@ export class User {
         },
     })
     scrappedQuestionLists: QuestionList[];
+
+    @Column({
+        type: "enum",
+        enum: LoginType,
+        default: LoginType.LOCAL,
+    })
+    loginType: LoginType;
+
+    @Column({ length: User.URL_MAX_LEN, nullable: true })
+    avatarUrl: string;
 }

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,7 +1,13 @@
 import { Module } from "@nestjs/common";
 import { UserRepository } from "./user.repository";
+import { UserService } from "@/user/user.service";
+import { AuthService } from "@/auth/auth.service";
+import { JwtModule } from "@/auth/jwt/jwt.module";
+import { UserController } from "@/user/user.controller";
 
 @Module({
-    providers: [UserRepository],
+    imports: [JwtModule],
+    controllers: [UserController],
+    providers: [UserRepository, UserService, AuthService],
 })
 export class UserModule {}

--- a/backend/src/user/user.repository.ts
+++ b/backend/src/user/user.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { User } from "./user.entity";
 import { DataSource } from "typeorm";
-import { CreateUserDto } from "./dto/create-user.dto";
+import { CreateUserInternalDto } from "./dto/create-user.dto";
 import { UserDto } from "./dto/user.dto";
 
 @Injectable()
@@ -24,7 +24,16 @@ export class UserRepository {
             .getOne();
     }
 
-    createUser(createUserDto: CreateUserDto) {
+    // TODO: 로그인 ID로 인덱싱 생성 필요?
+    getUserByLoginId(username: string) {
+        return this.dataSource
+            .getRepository(User)
+            .createQueryBuilder("user")
+            .where("user.login_id = :id", { id: username })
+            .getOne();
+    }
+
+    createUser(createUserDto: CreateUserInternalDto) {
         return this.dataSource.getRepository(User).save(createUserDto);
     }
 

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,0 +1,74 @@
+import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import { UserRepository } from "@/user/user.repository";
+import "dotenv/config";
+import { ChangePassword, UpdateUserDto } from "@/user/dto/update-user.dto";
+import { AuthService } from "@/auth/auth.service";
+import { Transactional } from "typeorm-transactional";
+import { LoginType, User } from "@/user/user.entity";
+import { CreateUserDto, CreateUserInternalDto } from "@/user/dto/create-user.dto";
+
+@Injectable()
+export class UserService {
+    constructor(
+        private readonly userRepository: UserRepository,
+        private readonly authService: AuthService
+    ) {}
+
+    public async getChangeableUserInfo(userId: number) {
+        const user = await this.userRepository.getUserByUserId(userId);
+        if (!user) throw new NotFoundException("User not found");
+        return {
+            userId: user.id,
+            nickname: user.username,
+            avatarUrl: user.avatarUrl,
+            loginType: user.loginType,
+        };
+    }
+
+    @Transactional()
+    public async updateUserInfo(userId: number, dto: UpdateUserDto) {
+        const user = await this.userRepository.getUserByUserId(userId);
+        if (!user) throw new BadRequestException("invalid user!");
+
+        const validPasswordDto =
+            dto.password &&
+            dto.password.original &&
+            dto.password.newPassword &&
+            user.loginType === LoginType.LOCAL;
+
+        user.avatarUrl = dto.avatarUrl || user.avatarUrl;
+        user.passwordHash = validPasswordDto
+            ? await this.changePassword(user, dto.password)
+            : user.passwordHash;
+        user.username = dto.nickname || user.username;
+
+        await this.userRepository.updateUser(user);
+        return dto;
+    }
+
+    @Transactional()
+    public async createUserByLocal(dto: CreateUserDto) {
+        const userDto: CreateUserInternalDto = {
+            loginId: dto.id,
+            loginType: LoginType.LOCAL,
+            username: dto.nickname,
+            passwordHash: this.authService.generatePasswordHash(dto.password),
+        };
+
+        await this.userRepository.createUser(userDto);
+
+        return {
+            status: "success",
+        };
+    }
+
+    @Transactional()
+    private async changePassword(user: User, pair: ChangePassword) {
+        const originalHash = this.authService.generatePasswordHash(pair.original);
+
+        if (originalHash !== user.passwordHash)
+            throw new BadRequestException("password does not match!");
+
+        return this.authService.generatePasswordHash(pair.newPassword);
+    }
+}

--- a/backend/src/utils/time.ts
+++ b/backend/src/utils/time.ts
@@ -1,4 +1,4 @@
-export const SEC = 1;
+export const SEC = 1000;
 export const MIN = 60 * SEC;
 export const HOUR = 60 * MIN;
 export const DAY = 24 * HOUR;


### PR DESCRIPTION
> [!note]
>
> 한꺼번에 많은 PR을 올리지 않도록 분리하였습니다. (제가 코드를 빨리치다보니 이걸 좀 분리하고싶은데 고민이네요.)
> #260 
> #261
> 을 먼저 확인해주세요. 이 PR과 연관되어있어서 이 PR 이 머지되면 저곳도 머지 됩니다.

## 관련 이슈 번호
> - 작성자: 김찬우
> - 작성 날짜: 2024.11.28

- #13 
- #12 

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- 로그인 회원가입 기능을 위한 DTO 추가 
- 로그인 기능을 위한 passport 전략 추가
- 쿠키 설정 시 secure 값을 production 일때만 되도록 허용


## 📝 작업 상세 내역

### 로그인 회원가입 기능을 위한 DTO 추가 
- 회원가입을 위한 DTO 추가
- 로그인을 위한 DTO 추가
- DTO가 좀 여러개 변경사항을 확인해보셔야할 거에요.
- `저한테 말 거시면 상세히 알려드리겠습니다.`

### 로그인 기능을 위한 passport 전략 추가
- 실제 인증은 `auth` 에서 합니다.
- 유저는 유저 정보 자체를 다루는데 집중하고, 해야할 것 같았습니다.
- 패스워드 해시 생성도 인증쪽에서 다루도록 바꾸었습니다.

```ts
import { Strategy } from "passport-local";
import { PassportStrategy } from "@nestjs/passport";
import { Injectable, UnauthorizedException } from "@nestjs/common";
import { JwtService } from "@/auth/jwt/jwt.service";
import { AuthService } from "@/auth/auth.service";

@Injectable()
export class LocalStrategy extends PassportStrategy(Strategy) {
    constructor(
        private readonly authService: AuthService,
        private readonly jwtService: JwtService
    ) {
        super({
            usernameField: "userId",
            passwordField: "password",
        });
    }

    async validate(username: string, password: string): Promise<any> {
        const user = await this.authService.getUserByLocal(username, password);

        if (!user) throw new UnauthorizedException("Invalid User login!");
        const token = await this.jwtService.createJwtToken(user);

        return {
            jwtToken: token,
        };
    }
}

```

- 보시는 것처럼 API 명세도 맞추어서 적용했습니다

### 쿠키 설정 시 secure 값을 production 일때만 되도록 허용

- 쿠키 설정할 때 로컬에서 테스트할 때 안될 것 같아서 http 일때 허용하도록 했습니다.
- 실제 빌드할 때도 `NODE_ENV` 를 설정하게 하는건 #259 여기서 추가했습니다.

```ts
import "dotenv/config";

export const setCookieConfig = {
    httpOnly: true,
    secure: process.env.NODE_ENV === "production",
};
```

## 📌 테스트 및 검증 결과
- POSTMAN으로 요청했습니다.
- 실제 데이터베이스에 회원가입은 잘 됩니다!
- 로그인은 POSTMAN으로 확인했습니다.


## 💬 다음 작업 또는 논의 사항
- 기능 개발은 여기까지가 끝입니다. (안심하세요..)
- 스터디 세션 hex 코드로 서렂ㅇ해서 길이가 길어서 불편했을 텐데, 그걸 base64 기반으로 인코딩으로 바꿨는데, 다음 PR 에 올리겠습니다.

## 🐥 리뷰 받고 싶은 포인트
- 연관성이 있는 긴 작업을 할 때 어떻게 해야할지 참 고민입니다.