### PR TITLE
[Fix] 중복 닉네임 요청 시 400번 반환되도록 수정

### DIFF
--- a/backend/src/user/user.repository.ts
+++ b/backend/src/user/user.repository.ts
@@ -1,43 +1,37 @@
 import { Injectable } from "@nestjs/common";
 import { User } from "./user.entity";
-import { DataSource } from "typeorm";
+import { DataSource, Repository } from "typeorm";
 import { CreateUserInternalDto } from "./dto/create-user.dto";
 import { UserDto } from "./dto/user.dto";
 
 @Injectable()
-export class UserRepository {
-    constructor(private dataSource: DataSource) {}
+export class UserRepository extends Repository<User> {
+    constructor(private dataSource: DataSource) {
+        super(User, dataSource.createEntityManager());
+    }
 
     getUserByGithubId(githubId: number) {
-        return this.dataSource
-            .getRepository(User)
-            .createQueryBuilder("user")
+        return this.createQueryBuilder("user")
             .where("user.github_id = :id", { id: githubId })
             .getOne();
     }
 
     getUserByUserId(userId: number) {
-        return this.dataSource
-            .getRepository(User)
-            .createQueryBuilder("user")
-            .where("user.id = :id", { id: userId })
-            .getOne();
+        return this.createQueryBuilder("user").where("user.id = :id", { id: userId }).getOne();
     }
 
     // TODO: 로그인 ID로 인덱싱 생성 필요?
     getUserByLoginId(username: string) {
-        return this.dataSource
-            .getRepository(User)
-            .createQueryBuilder("user")
+        return this.createQueryBuilder("user")
             .where("user.login_id = :id", { id: username })
             .getOne();
     }
 
     createUser(createUserDto: CreateUserInternalDto) {
-        return this.dataSource.getRepository(User).save(createUserDto);
+        return this.save(createUserDto);
     }
 
     updateUser(userDto: UserDto) {
-        return this.dataSource.getRepository(User).save(userDto);
+        return this.save(userDto);
     }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,4 +1,9 @@
-import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import {
+    BadRequestException,
+    ConflictException,
+    Injectable,
+    NotFoundException,
+} from "@nestjs/common";
 import { UserRepository } from "@/user/user.repository";
 import "dotenv/config";
 import { ChangePassword, UpdateUserDto } from "@/user/dto/update-user.dto";
@@ -65,7 +70,7 @@ export class UserService {
         } catch (e) {
             if (!(e instanceof QueryFailedError) || !e.driverError.code) throw e;
             if (e.driverError.code === "ER_DUP_ENTRY")
-                throw new BadRequestException("중복된 닉네임입니다.");
+                throw new ConflictException("중복된 닉네임입니다.");
         }
     }
 


### PR DESCRIPTION
- 닉네임 생성 시 에러코드 400 번 출력되도록 수정
- 유저의 잘못된 요청이므로 Bad request가 적절하다고 판단


## 관련 이슈

<img width="742" alt="image" src="https://github.com/user-attachments/assets/aac07c2b-6401-4455-9e92-17460291ea8f">


## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- 유저 생성 시 에러코드 출력되도록 수정

## 📝 작업 상세 내역

### 닉네임 생성 시 에러코드 400 번 출력되도록 수정

- 유저의 잘못된 요청이므로 Bad request가 적절하다고 판단했습니다.


## 📌 테스트 및 검증 결과
- 이제 드뮴님을 한분 밖에 생성하지 못합니다.(?)

![image](https://github.com/user-attachments/assets/8fad9550-f828-4d75-ba7b-837700814644)

## 💬 다음 작업 또는 논의 사항
- 열심히 리팩토링 중입니다.
- `DDD` 쪽을 참고해서 도메인 쪽에서도 스스로 간단한 동작을 수행할 수 있게 책임분리 중입니다.
- 인프라쪽도 관심 분리중입니다~ 웹소켓인데 redis client 쪽도 담당하고 있더라고요.
- 레포지토리도 DB 접근만 책임지도록 관심분리중입니다!
- 서비스도 그냥 통합중입니다. 멘토님 피드백 이후, 코드 수보다 책임이 중요하다고 판단했기 때문입니다.

## 🐥 리뷰 받고 싶은 포인트
- `혹시 모르니,, if 문 맞는지만 확인해주세요!`