### PR TITLE
[Feat] 401에러에 대한 처리 axios 인터셉터 사용, 최소 질문 길이 5자로 수정

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -40,7 +40,7 @@ export class AuthController {
         @Res({ passthrough: true }) res: Response,
         @JwtTokenPair() pair: IJwtTokenPair
     ) {
-        if (!pair) throw new UnauthorizedException();
+        if (!pair) throw new InternalServerErrorException();
         return this.setCookie(res, pair.accessToken);
     }
 

--- a/backend/src/auth/jwt/jwt.service.ts
+++ b/backend/src/auth/jwt/jwt.service.ts
@@ -60,7 +60,9 @@ export class JwtService {
 
     private async createRefreshToken(id: number): Promise<IJwtToken> {
         const refreshToken = this.parent.sign(
-            {},
+            {
+                exp: Date.now() + JwtService.REFRESH_TOKEN_TIME,
+            },
             {
                 secret: process.env.JWT_REFRESH_TOKEN_SECRET_KEY,
                 audience: String(id),

--- a/backend/src/auth/jwt/strategy/refresh-token.strategy.ts
+++ b/backend/src/auth/jwt/strategy/refresh-token.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
 import { Strategy } from "passport-jwt";
 import { Request } from "express";
@@ -21,6 +21,9 @@ export class RefreshTokenStrategy extends PassportStrategy(Strategy, "jwt-refres
 
     async validate(req: Request, payload: any) {
         const { aud, exp } = payload;
+
+        if (!exp || exp < Date.now()) throw new UnauthorizedException();
+
         const refreshToken = req.cookies["refreshToken"];
 
         const accessToken = await this.jwtService.getNewAccessToken(parseInt(aud), refreshToken);

--- a/frontend/src/api/config/axios.ts
+++ b/frontend/src/api/config/axios.ts
@@ -15,12 +15,11 @@ api.interceptors.response.use(
     if (error.response?.status === 401) {
       try {
         const response = await refreshAccessToken();
-        console.log(response);
         if (response.data.success) {
           return axios(originalRequest!);
         }
       } catch (error) {
-        console.log("토큰 재발급 실패", error);
+        console.error("토큰 재발급 실패", error);
         alert("세션이 만료되었습니다. 다시 로그인해주세요.");
         useAuthStore.persist.clearStorage();
         window.location.href = "/login";

--- a/frontend/src/api/config/axios.ts
+++ b/frontend/src/api/config/axios.ts
@@ -1,44 +1,29 @@
 import axios, { AxiosError } from "axios";
-import useAuth from "@hooks/useAuth.ts";
-import { useNavigate } from "react-router-dom";
 import { refreshAccessToken } from "@/api/user/auth.ts";
+import useAuthStore from "@stores/useAuthStore.ts";
 
 export const api = axios.create({
   timeout: 5000,
   withCredentials: true,
 });
 
-// 401에러일때의 처리
-// 현재 서비스를 사용하다가 인증 에러가 난거니까 현재 서비스 url을 기록하고 로그인 후 복귀 하는 것을 목표
 api.interceptors.response.use(
-  (response) => {
-    return response;
-  },
+  (response) => response,
   async (error: AxiosError) => {
     const originalRequest = error.config;
 
     if (error.response?.status === 401) {
       try {
         const response = await refreshAccessToken();
+        console.log(response);
         if (response.data.success) {
-          // 토큰 갱신 성공 요청 다시 보내기
           return axios(originalRequest!);
-        } else {
-          // 토큰 갱신 실패
-          // 로그아웃 처리
-          // 로그인 페이지로 리다이렉팅
-          const { logOut } = useAuth();
-          const navigate = useNavigate();
-          const currentPath = window.location.pathname;
-          localStorage.setItem("redirectUrl", currentPath);
-
-          // 로그아웃처리
-          logOut();
-
-          // 로그인 페이지로 리다이렉트
-          navigate("/login", { replace: true });
         }
       } catch (error) {
+        console.log("토큰 재발급 실패", error);
+        alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+        useAuthStore.persist.clearStorage();
+        window.location.href = "/login";
         return Promise.reject(error);
       }
     }

--- a/frontend/src/api/user/auth.ts
+++ b/frontend/src/api/user/auth.ts
@@ -1,0 +1,5 @@
+import axios from "axios";
+
+export const refreshAccessToken = async () => {
+  return await axios.post("/api/auth/refresh");
+};

--- a/frontend/src/api/user/auth.ts
+++ b/frontend/src/api/user/auth.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
 
 export const refreshAccessToken = async () => {
-  return await axios.post("/api/auth/refresh");
+  return await axios.get("/api/auth/refresh");
 };

--- a/frontend/src/components/questions/create/QuestionInputSection/QuestionInput.tsx
+++ b/frontend/src/components/questions/create/QuestionInputSection/QuestionInput.tsx
@@ -16,11 +16,11 @@ const QuestionInput = () => {
   };
 
   const addInput = () => {
-    if (inputValue.trim().length >= 10) {
+    if (inputValue.trim().length >= 5) {
       addQuestion(inputValue.trim());
       setInputValue("");
     } else {
-      toast.error("질문은 10자 이상 입력해주세요.");
+      toast.error("질문은 5자 이상 입력해주세요.");
     }
   };
 

--- a/frontend/src/pages/Login/AuthCallbackPage.tsx
+++ b/frontend/src/pages/Login/AuthCallbackPage.tsx
@@ -34,7 +34,9 @@ const AuthCallbackPage = () => {
         } catch (error) {
           console.error("Failed to get user info", error);
         } finally {
-          navigate("/");
+          const redirectUrl = localStorage.getItem("redirectUrl") || "/";
+          localStorage.removeItem("redirectUrl");
+          navigate(redirectUrl);
         }
       }
     } catch (error) {

--- a/frontend/src/pages/Login/hooks/useValidate.ts
+++ b/frontend/src/pages/Login/hooks/useValidate.ts
@@ -39,7 +39,9 @@ const useValidate = ({ setIsSignUp }: UseValidateProps) => {
         toast.success("로그인에 성공했습니다.");
         auth.logIn();
         auth.setNickname(nickname);
-        navigate("/");
+        const redirectUrl = localStorage.getItem("redirectUrl") || "/";
+        localStorage.removeItem("redirectUrl");
+        navigate(redirectUrl);
       }
     } catch (err) {
       if (isAxiosError(err)) {

--- a/frontend/src/pages/Login/view/OAuthContainer.tsx
+++ b/frontend/src/pages/Login/view/OAuthContainer.tsx
@@ -20,7 +20,9 @@ const OAuthContainer = () => {
       toast.success(
         "게스트로 로그인되었습니다. 환영합니다. " + nickname + "님!"
       );
-      navigate("/");
+      const redirectUrl = localStorage.getItem("redirectUrl") || "/";
+      localStorage.removeItem("redirectUrl");
+      navigate(redirectUrl);
     }
   };
 

--- a/frontend/src/pages/MyPage/MyPage.tsx
+++ b/frontend/src/pages/MyPage/MyPage.tsx
@@ -1,21 +1,6 @@
-import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-import useAuth from "@hooks/useAuth";
-import useToast from "@hooks/useToast";
 import MyPageView from "./view/MyPageView";
 
 const MyPage = () => {
-  const { isLoggedIn } = useAuth();
-  const toast = useToast();
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (!isLoggedIn) {
-      toast.error("로그인이 필요한 서비스입니다.");
-      navigate("/login", { replace: true });
-    }
-  }, [isLoggedIn, navigate, toast]);
-
   return <MyPageView />;
 };
 

--- a/frontend/src/pages/QuestionListPage/view/Tabs.tsx
+++ b/frontend/src/pages/QuestionListPage/view/Tabs.tsx
@@ -1,3 +1,5 @@
+import useAuth from "@hooks/useAuth.ts";
+
 interface TabsProps {
   tab: "ALL" | "SCRAP";
   setTab: (value: "ALL" | "SCRAP") => void;
@@ -5,26 +7,31 @@ interface TabsProps {
 type Tab = "ALL" | "SCRAP";
 
 const Tabs = ({ tab, setTab }: TabsProps) => {
+  const { isLoggedIn } = useAuth();
+
   const tabs = [
     { name: "모든 질문지", value: "ALL" },
-    { name: "스크랩한 질문지", value: "SCRAP" },
+    isLoggedIn ? { name: "스크랩한 질문지", value: "SCRAP" } : null,
   ];
-  const selectedTab = tabs.findIndex((t) => t.value === tab);
+  const selectedTab = tabs.findIndex((t) => t && t.value === tab);
   const selectedClassName = "text-green-600 text-semibold-r";
 
   return (
     <div className={"relative border-b mt-4 pt-4 py-2 flex gap-4  "}>
-      {tabs.map((tab, index) => (
-        <button
-          key={tab.value}
-          onClick={() => setTab(tab.value as Tab)}
-          className={`w-28 h-full ${
-            selectedTab === index ? selectedClassName : ""
-          }`}
-        >
-          {tab.name}
-        </button>
-      ))}
+      {tabs.map(
+        (tab, index) =>
+          tab && (
+            <button
+              key={tab.value}
+              onClick={() => setTab(tab.value as Tab)}
+              className={`w-28 h-full ${
+                selectedTab === index ? selectedClassName : ""
+              }`}
+            >
+              {tab.name}
+            </button>
+          )
+      )}
       <div
         className={`absolute -z-0 pointer-events-none top-0 ${tab === "SCRAP" ? "left-32" : "left-0"} transition-all duration-200 pt-4 py-2 p-1 border-b border-green-200 h-full w-28`}
       ></div>

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -41,7 +41,11 @@ export const routes = [
     path: "/login/callback",
   },
   {
-    element: <MyPage />,
+    element: (
+      <ProtectedRouteLayout>
+        <MyPage />
+      </ProtectedRouteLayout>
+    ),
     path: "/mypage",
   },
   {


### PR DESCRIPTION
 
## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- axios 인스턴스를 사용하는 요청에 대한 응답으로 401에러가 발생할 경우에 대한 처리를 일관적으로 하기 위해 인터셉터 도입
- 리프레시 토큰으로 재발급 시도하고 성공하면 요청 재시도
- 실패할 경우에는 세션 만료 alert 출력 후 로그인하도록 

### 질문 길이 수정
- 원래 10자였는데 5자로 줄였습니다. 테스트하면서 10자 좀 불편했어서 바꿨는데 10자보다 적은 질문도 있고해서 괜찮은 것 같습니다.

