### PR TITLE
[Feat] `GET /api/rooms` 요청에 대해 필터링 추가 옵션 제공

### DIFF
--- a/backend/src/room/dto/all-room.dto.ts
+++ b/backend/src/room/dto/all-room.dto.ts
@@ -1,0 +1,14 @@
+// DTO 클래스 정의
+import { Transform } from "class-transformer";
+import { IsBoolean, IsOptional } from "class-validator";
+
+export class AllRoomQueryParamDto {
+    @IsOptional()
+    @Transform(({ value }) => {
+        if (value === "true") return true;
+        if (value === "false") return false;
+        return value;
+    })
+    @IsBoolean()
+    inProgress: boolean;
+}

--- a/backend/src/room/room.controller.ts
+++ b/backend/src/room/room.controller.ts
@@ -1,13 +1,15 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, Query, UsePipes, ValidationPipe } from "@nestjs/common";
 import { RoomService } from "./services/room.service";
+import { AllRoomQueryParamDto } from "@/room/dto/all-room.dto";
 
 @Controller("rooms")
 export class RoomController {
     constructor(private readonly roomService: RoomService) {}
 
     @Get()
-    public async getPublicRoom() {
-        const rooms = await this.roomService.getPublicRoom();
+    @UsePipes(new ValidationPipe({ transform: true }))
+    public async getPublicRoom(@Query() query: AllRoomQueryParamDto) {
+        const rooms = await this.roomService.getPublicRoom(query.inProgress);
         return rooms.map((room) => ({
             ...room,
             connectionMap: undefined,

--- a/backend/src/room/services/room.service.ts
+++ b/backend/src/room/services/room.service.ts
@@ -7,10 +7,14 @@ import { RoomListResponseDto } from "@/room/dto/room-list.dto";
 export class RoomService {
     public constructor(private readonly roomRepository: RoomRepository) {}
 
-    public async getPublicRoom(): Promise<RoomListResponseDto> {
+    public async getPublicRoom(inProgress?: boolean): Promise<RoomListResponseDto> {
         const rooms = await this.roomRepository.getAllRoom();
         return rooms
-            .filter((room) => room.status === RoomStatus.PUBLIC)
+            .filter(
+                (room) =>
+                    room.status === RoomStatus.PUBLIC &&
+                    (inProgress === undefined || room.inProgress === inProgress)
+            )
             .sort((a, b) => b.createdAt - a.createdAt)
             .map((room) => ({
                 createdAt: room.createdAt,


### PR DESCRIPTION
> [!note]
> - 작성자: 김찬우
> - 작성 날짜: 2024.12.03

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- `GET /api/rooms` 요청에 대해 필터링 추가 옵션 제공

## 📝 작업 상세 내역
### `GET /api/rooms` 요청에 대해 필터링 추가 옵션 제공
- `queryParam` 으로 `inProgress` 에 `true` 혹은 `false` 등으로 추가 필터링 가능
- 명세서도 수정해두었습니다.
<img width="779" alt="image" src="https://github.com/user-attachments/assets/84880484-cf62-4ea3-be1d-e0425eeed53f">

- `/api/rooms?inProgress=true` 이렇게 쓰면 됩니다.

## 📌 테스트 및 검증 결과
- Postman 으로 테스트 후 잘 작동!