### PR TITLE
[Refactor] 로그인 유무에 따른 에러 처리와 응답 반환

### DIFF
--- a/backend/src/question-list/dto/get-all-question-list.dto.ts
+++ b/backend/src/question-list/dto/get-all-question-list.dto.ts
@@ -4,4 +4,5 @@ export interface GetAllQuestionListDto {
     categoryNames: string[];
     usage: number;
     questionCount: number;
+    isScrap: boolean;
 }

--- a/backend/src/question-list/dto/question-list-contents.dto.ts
+++ b/backend/src/question-list/dto/question-list-contents.dto.ts
@@ -7,4 +7,5 @@ export interface QuestionListContentsDto {
     contents: Question[];
     usage: number;
     username: string;
+    isScrap: boolean;
 }

--- a/backend/src/question-list/dto/question-list-contents.dto.ts
+++ b/backend/src/question-list/dto/question-list-contents.dto.ts
@@ -8,4 +8,5 @@ export interface QuestionListContentsDto {
     usage: number;
     username: string;
     isScrap: boolean;
+    scrapCount: number;
 }

--- a/backend/src/question-list/question-list.controller.ts
+++ b/backend/src/question-list/question-list.controller.ts
@@ -3,11 +3,13 @@ import {
     Controller,
     Delete,
     Get,
+    HttpStatus,
     Param,
     Patch,
     Post,
     Query,
     Req,
+    Res,
     UseGuards,
     UsePipes,
     ValidationPipe,
@@ -28,31 +30,43 @@ export class QuestionListController {
     constructor(private readonly questionListService: QuestionListService) {}
 
     @Get()
+    @UseGuards(AuthGuard("jwt"))
     @UsePipes(new ValidationPipe({ transform: true }))
-    async getAllQuestionLists(@Query() query: PaginateQueryDto) {
+    async getAllQuestionLists(
+        @Res() res,
+        @Query() query: PaginateQueryDto,
+        @JwtPayload() token: IJwtPayload
+    ) {
         try {
+            if (!token) {
+                // 로그인 안함
+                // isScrap: false
+            }
             const { allQuestionLists, meta } =
                 await this.questionListService.getAllQuestionLists(query);
-            return {
+            return res.status(HttpStatus.OK).json({
                 success: true,
                 message: "All question lists received successfully.",
                 data: {
                     allQuestionLists,
                     meta,
                 },
-            };
+            });
         } catch (error) {
-            return {
+            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: "Failed to get all question lists.",
                 error: error.message,
-            };
+            });
         }
     }
 
     @Post("category")
+    @UseGuards(AuthGuard("jwt"))
     @UsePipes(new ValidationPipe({ transform: true }))
     async getAllQuestionListsByCategoryName(
+        @Res() res,
+        @JwtPayload() token: IJwtPayload,
         @Query() query: PaginateQueryDto,
         @Body()
         body: {
@@ -60,24 +74,28 @@ export class QuestionListController {
         }
     ) {
         try {
+            if (!token) {
+                // 로그인 안함
+                // isScrap: false
+            }
             const { categoryName } = body;
             query.category = categoryName;
             const { allQuestionLists, meta } =
                 await this.questionListService.getAllQuestionLists(query);
-            return {
+            return res.status(HttpStatus.OK).json({
                 success: true,
                 message: "All question lists received successfully.",
                 data: {
                     allQuestionLists,
                     meta,
                 },
-            };
+            });
         } catch (error) {
-            return {
+            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: "Failed to get all question lists.",
                 error: error.message,
-            };
+            });
         }
     }
 
@@ -85,6 +103,7 @@ export class QuestionListController {
     @UseGuards(AuthGuard("jwt"))
     async createQuestionList(
         @JwtPayload() token: IJwtPayload,
+        @Res() res,
         @Req() req,
         @Body()
         body: {
@@ -96,6 +115,11 @@ export class QuestionListController {
     ) {
         try {
             const { title, contents, categoryNames, isPublic } = body;
+            if (!token)
+                return res.status(HttpStatus.UNAUTHORIZED).json({
+                    success: false,
+                    message: "Login required.",
+                });
 
             // 질문지 DTO 준비
             const createQuestionListDto: CreateQuestionListDto = {
@@ -109,26 +133,27 @@ export class QuestionListController {
             // 질문지 생성
             const { createdQuestionList, createdQuestions } =
                 await this.questionListService.createQuestionList(createQuestionListDto);
-            return {
+            return res.status(HttpStatus.OK).json({
                 success: true,
                 message: "Question list created successfully.",
                 data: {
                     createdQuestionList,
                     createdQuestions,
                 },
-            };
+            });
         } catch (error) {
-            return {
+            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: "Failed to create question list.",
                 error: error.message,
-            };
+            });
         }
     }
 
     @Post("contents")
     @UseGuards(AuthGuard("jwt"))
     async getQuestionListContents(
+        @Res() res,
         @JwtPayload() token: IJwtPayload,
         @Body()
         body: {
@@ -136,62 +161,84 @@ export class QuestionListController {
         }
     ) {
         try {
+            if (!token) {
+                // 로그인 안함
+                // isScrap: false
+                // 비공개 질문 접근 불가 처리
+            }
             const userId = token.userId;
             const { questionListId } = body;
             const questionListContents: QuestionListContentsDto =
                 await this.questionListService.getQuestionListContents(questionListId, userId);
-            return {
+            return res.status(HttpStatus.OK).json({
                 success: true,
                 message: "Question list contents received successfully.",
                 data: {
                     questionListContents,
                 },
-            };
+            });
         } catch (error) {
-            return {
+            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: "Failed to get question list contents.",
                 error: error.message,
-            };
+            });
         }
     }
 
     @Get("my")
     @UseGuards(AuthGuard("jwt"))
     @UsePipes(new ValidationPipe({ transform: true }))
-    async getMyQuestionLists(@Query() query: PaginateQueryDto, @JwtPayload() token: IJwtPayload) {
+    async getMyQuestionLists(
+        @Res() res,
+        @Query() query: PaginateQueryDto,
+        @JwtPayload() token: IJwtPayload
+    ) {
         try {
+            if (!token)
+                return res.status(HttpStatus.UNAUTHORIZED).json({
+                    success: false,
+                    message: "Login required.",
+                });
             const userId = token.userId;
+
             const { myQuestionLists, meta } = await this.questionListService.getMyQuestionLists(
                 userId,
                 query
             );
-            return {
+            return res.status(HttpStatus.OK).json({
                 success: true,
                 message: "My question lists received successfully.",
                 data: {
                     myQuestionLists,
                     meta,
                 },
-            };
+            });
         } catch (error) {
-            return {
+            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: "Failed to get my question lists.",
                 error: error.message,
-            };
+            });
         }
     }
 
     @Patch("/:questionListId")
     @UseGuards(AuthGuard("jwt"))
     async updateQuestionList(
+        @Res() res,
         @JwtPayload() token: IJwtPayload,
         @Param("questionListId") questionListId: number,
         @Body() body: { title?: string; isPublic?: boolean; categoryNames?: string[] }
     ) {
         try {
+            if (!token)
+                return res.status(HttpStatus.UNAUTHORIZED).json({
+                    success: false,
+                    message: "Login required.",
+                });
             const userId = token.userId;
+
             const { title, isPublic, categoryNames } = body;
             const updateQuestionListDto: UpdateQuestionListDto = {
                 id: questionListId,
@@ -203,64 +250,78 @@ export class QuestionListController {
 
             const updatedQuestionList =
                 await this.questionListService.updateQuestionList(updateQuestionListDto);
-            return {
+            return res.status(HttpStatus.OK).json({
                 success: true,
                 message: "Question list is updated successfully.",
                 data: {
                     questionList: updatedQuestionList,
                 },
-            };
+            });
         } catch (error) {
-            return {
+            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: "Failed to update question list.",
                 error: error.message,
-            };
+            });
         }
     }
 
     @Delete("/:questionListId")
     @UseGuards(AuthGuard("jwt"))
     async deleteQuestionList(
+        @Res() res,
         @JwtPayload() token: IJwtPayload,
         @Param("questionListId") questionListId: number
     ) {
         try {
+            if (!token)
+                return res.status(HttpStatus.UNAUTHORIZED).json({
+                    success: false,
+                    message: "Login required.",
+                });
             const userId = token.userId;
+
             const result = await this.questionListService.deleteQuestionList(
                 questionListId,
                 userId
             );
 
             if (result.affected) {
-                return {
+                return res.status(HttpStatus.OK).json({
                     success: true,
                     message: "Question list is deleted successfully.",
-                };
+                });
             } else {
-                return {
-                    success: true,
+                return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+                    success: false,
                     message: "Failed to delete question list.",
-                };
+                });
             }
         } catch (error) {
-            return {
+            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: true,
                 message: "Failed to delete question list.",
                 error: error.message,
-            };
+            });
         }
     }
 
     @Post("/:questionListId/question")
     @UseGuards(AuthGuard("jwt"))
     async addQuestion(
+        @Res() res,
         @JwtPayload() token: IJwtPayload,
         @Body() body: { content: string },
         @Param("questionListId") questionListId: number
     ) {
         try {
+            if (!token)
+                return res.status(HttpStatus.UNAUTHORIZED).json({
+                    success: false,
+                    message: "Login required.",
+                });
             const userId = token.userId;
+
             const { content } = body;
             const questionDto: QuestionDto = {
                 content,
@@ -270,31 +331,38 @@ export class QuestionListController {
 
             const result = await this.questionListService.addQuestion(questionDto);
 
-            return {
+            return res.status(HttpStatus.OK).json({
                 success: true,
                 message: "The new question is added to the list successfully.",
                 data: {
                     questionList: result,
                 },
-            };
+            });
         } catch (error) {
-            return {
+            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: "Failed to add the new question to the list.",
                 error: error.message,
-            };
+            });
         }
     }
 
     @Patch("/:questionListId/question/:questionId")
     @UseGuards(AuthGuard("jwt"))
     async updateQuestion(
+        @Res() res,
         @JwtPayload() token: IJwtPayload,
         @Body() body: { content: string },
         @Param() params: { questionListId: number; questionId: number }
     ) {
         try {
+            if (!token)
+                return res.status(HttpStatus.UNAUTHORIZED).json({
+                    success: false,
+                    message: "Login required.",
+                });
             const userId = token.userId;
+
             const { content } = body;
             const { questionListId, questionId } = params;
             const questionDto: QuestionDto = {
@@ -306,30 +374,37 @@ export class QuestionListController {
 
             const result = await this.questionListService.updateQuestion(questionDto);
 
-            return {
+            return res.status(HttpStatus.OK).json({
                 success: true,
                 message: "Question is updated successfully.",
                 data: {
                     questionList: result,
                 },
-            };
+            });
         } catch (error) {
-            return {
+            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: "Failed to update question.",
                 error: error.message,
-            };
+            });
         }
     }
 
     @Delete("/:questionListId/question/:questionId")
     @UseGuards(AuthGuard("jwt"))
     async deleteQuestion(
+        @Res() res,
         @JwtPayload() token: IJwtPayload,
         @Param() params: { questionListId: number; questionId: number }
     ) {
         try {
+            if (!token)
+                return res.status(HttpStatus.UNAUTHORIZED).json({
+                    success: false,
+                    message: "Login required.",
+                });
             const userId = token.userId;
+
             const { questionListId, questionId } = params;
             const deleteQuestionDto: DeleteQuestionDto = {
                 id: questionId,
@@ -338,22 +413,22 @@ export class QuestionListController {
             };
             const result = await this.questionListService.deleteQuestion(deleteQuestionDto);
             if (result.affected) {
-                return {
+                return res.status(HttpStatus.OK).json({
                     success: true,
                     message: "Question is deleted successfully.",
-                };
+                });
             } else {
-                return {
-                    success: true,
+                return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+                    success: false,
                     message: "Failed to delete question.",
-                };
+                });
             }
         } catch (error) {
-            return {
+            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: "Failed to delete question.",
                 error: error.message,
-            };
+            });
         }
     }
 
@@ -361,90 +436,111 @@ export class QuestionListController {
     @UseGuards(AuthGuard("jwt"))
     @UsePipes(new ValidationPipe({ transform: true }))
     async getScrappedQuestionLists(
+        @Res() res,
         @Query() query: PaginateQueryDto,
         @JwtPayload() token: IJwtPayload
     ) {
         try {
+            if (!token)
+                return res.status(HttpStatus.UNAUTHORIZED).json({
+                    success: false,
+                    message: "Login required.",
+                });
             const userId = token.userId;
+
             const { scrappedQuestionLists, meta } =
                 await this.questionListService.getScrappedQuestionLists(userId, query);
-            return {
+            return res.status(HttpStatus.OK).json({
                 success: true,
                 message: "Scrapped question lists received successfully.",
                 data: {
                     questionList: scrappedQuestionLists,
                     meta,
                 },
-            };
+            });
         } catch (error) {
-            return {
+            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: "Failed to get scrapped question lists.",
                 error: error.message,
-            };
+            });
         }
     }
 
     @Post("scrap")
     @UseGuards(AuthGuard("jwt"))
     async scrapQuestionList(
+        @Res() res,
         @JwtPayload() token: IJwtPayload,
         @Body() body: { questionListId: number }
     ) {
         try {
+            if (!token)
+                return res.status(HttpStatus.UNAUTHORIZED).json({
+                    success: false,
+                    message: "Login required.",
+                });
             const userId = token.userId;
+
             const { questionListId } = body;
             const scrappedQuestionList = await this.questionListService.scrapQuestionList(
                 questionListId,
                 userId
             );
 
-            return {
+            return res.status(HttpStatus.OK).json({
                 success: true,
                 message: "Question list is scrapped successfully.",
                 data: {
                     questionList: scrappedQuestionList,
                 },
-            };
+            });
         } catch (error) {
-            return {
+            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: "Failed to scrap question list.",
                 error: error.message,
-            };
+            });
         }
     }
 
     @Delete("scrap/:questionListId")
     @UseGuards(AuthGuard("jwt"))
     async unscrapQuestionList(
+        @Res() res,
         @JwtPayload() token: IJwtPayload,
         @Param("questionListId") questionListId: number
     ) {
         try {
+            if (!token)
+                return res.status(HttpStatus.UNAUTHORIZED).json({
+                    success: false,
+                    message: "Login is required to create question list.",
+                });
             const userId = token.userId;
+
             const unscrappedQuestionList = await this.questionListService.unscrapQuestionList(
                 questionListId,
                 userId
             );
 
             if (unscrappedQuestionList.affected) {
-                return {
+                return res.status(HttpStatus.OK).json({
                     success: true,
                     message: "Question list unscrapped successfully.",
-                };
+                });
             } else {
-                return {
+                return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                     success: false,
                     message: "Failed to unscrap question list.",
-                };
+                });
             }
         } catch (error) {
-            return {
+            return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
                 success: false,
                 message: "Failed to unscrap question list.",
                 error: error.message,
-            };
+            });
         }
     }
 }

--- a/backend/src/question-list/question-list.controller.ts
+++ b/backend/src/question-list/question-list.controller.ts
@@ -115,7 +115,9 @@ export class QuestionListController {
     ) {
         try {
             const { title, contents, categoryNames, isPublic } = body;
-            if (!token)
+            const userId = token ? token.userId : null;
+
+            if (!userId)
                 return res.status(HttpStatus.UNAUTHORIZED).json({
                     success: false,
                     message: "Login required.",
@@ -127,7 +129,7 @@ export class QuestionListController {
                 contents,
                 categoryNames,
                 isPublic,
-                userId: token.userId,
+                userId,
             };
 
             // 질문지 생성
@@ -161,12 +163,14 @@ export class QuestionListController {
         }
     ) {
         try {
-            if (!token) {
+            const userId = token ? token.userId : null;
+
+            if (!userId) {
                 // 로그인 안함
                 // isScrap: false
                 // 비공개 질문 접근 불가 처리
             }
-            const userId = token.userId;
+
             const { questionListId } = body;
             const questionListContents: QuestionListContentsDto =
                 await this.questionListService.getQuestionListContents(questionListId, userId);
@@ -195,12 +199,13 @@ export class QuestionListController {
         @JwtPayload() token: IJwtPayload
     ) {
         try {
-            if (!token)
+            const userId = token ? token.userId : null;
+
+            if (!userId)
                 return res.status(HttpStatus.UNAUTHORIZED).json({
                     success: false,
                     message: "Login required.",
                 });
-            const userId = token.userId;
 
             const { myQuestionLists, meta } = await this.questionListService.getMyQuestionLists(
                 userId,
@@ -232,12 +237,13 @@ export class QuestionListController {
         @Body() body: { title?: string; isPublic?: boolean; categoryNames?: string[] }
     ) {
         try {
-            if (!token)
+            const userId = token ? token.userId : null;
+
+            if (!userId)
                 return res.status(HttpStatus.UNAUTHORIZED).json({
                     success: false,
                     message: "Login required.",
                 });
-            const userId = token.userId;
 
             const { title, isPublic, categoryNames } = body;
             const updateQuestionListDto: UpdateQuestionListDto = {
@@ -274,12 +280,13 @@ export class QuestionListController {
         @Param("questionListId") questionListId: number
     ) {
         try {
-            if (!token)
+            const userId = token ? token.userId : null;
+
+            if (!userId)
                 return res.status(HttpStatus.UNAUTHORIZED).json({
                     success: false,
                     message: "Login required.",
                 });
-            const userId = token.userId;
 
             const result = await this.questionListService.deleteQuestionList(
                 questionListId,
@@ -315,12 +322,13 @@ export class QuestionListController {
         @Param("questionListId") questionListId: number
     ) {
         try {
-            if (!token)
+            const userId = token ? token.userId : null;
+
+            if (!userId)
                 return res.status(HttpStatus.UNAUTHORIZED).json({
                     success: false,
                     message: "Login required.",
                 });
-            const userId = token.userId;
 
             const { content } = body;
             const questionDto: QuestionDto = {
@@ -356,12 +364,13 @@ export class QuestionListController {
         @Param() params: { questionListId: number; questionId: number }
     ) {
         try {
-            if (!token)
+            const userId = token ? token.userId : null;
+
+            if (!userId)
                 return res.status(HttpStatus.UNAUTHORIZED).json({
                     success: false,
                     message: "Login required.",
                 });
-            const userId = token.userId;
 
             const { content } = body;
             const { questionListId, questionId } = params;
@@ -398,12 +407,13 @@ export class QuestionListController {
         @Param() params: { questionListId: number; questionId: number }
     ) {
         try {
-            if (!token)
+            const userId = token ? token.userId : null;
+
+            if (!userId)
                 return res.status(HttpStatus.UNAUTHORIZED).json({
                     success: false,
                     message: "Login required.",
                 });
-            const userId = token.userId;
 
             const { questionListId, questionId } = params;
             const deleteQuestionDto: DeleteQuestionDto = {
@@ -441,12 +451,13 @@ export class QuestionListController {
         @JwtPayload() token: IJwtPayload
     ) {
         try {
-            if (!token)
+            const userId = token ? token.userId : null;
+
+            if (!userId)
                 return res.status(HttpStatus.UNAUTHORIZED).json({
                     success: false,
                     message: "Login required.",
                 });
-            const userId = token.userId;
 
             const { scrappedQuestionLists, meta } =
                 await this.questionListService.getScrappedQuestionLists(userId, query);
@@ -475,12 +486,13 @@ export class QuestionListController {
         @Body() body: { questionListId: number }
     ) {
         try {
-            if (!token)
+            const userId = token ? token.userId : null;
+
+            if (!userId)
                 return res.status(HttpStatus.UNAUTHORIZED).json({
                     success: false,
                     message: "Login required.",
                 });
-            const userId = token.userId;
 
             const { questionListId } = body;
             const scrappedQuestionList = await this.questionListService.scrapQuestionList(
@@ -512,12 +524,13 @@ export class QuestionListController {
         @Param("questionListId") questionListId: number
     ) {
         try {
-            if (!token)
+            const userId = token ? token.userId : null;
+
+            if (!userId)
                 return res.status(HttpStatus.UNAUTHORIZED).json({
                     success: false,
                     message: "Login is required to create question list.",
                 });
-            const userId = token.userId;
 
             const unscrappedQuestionList = await this.questionListService.unscrapQuestionList(
                 questionListId,

--- a/backend/src/question-list/question-list.controller.ts
+++ b/backend/src/question-list/question-list.controller.ts
@@ -38,12 +38,11 @@ export class QuestionListController {
         @JwtPayload() token: IJwtPayload
     ) {
         try {
-            if (!token) {
-                // 로그인 안함
-                // isScrap: false
-            }
-            const { allQuestionLists, meta } =
-                await this.questionListService.getAllQuestionLists(query);
+            const userId = token ? token.userId : null;
+            const { allQuestionLists, meta } = await this.questionListService.getAllQuestionLists(
+                query,
+                userId
+            );
             return res.status(HttpStatus.OK).json({
                 success: true,
                 message: "All question lists received successfully.",
@@ -74,14 +73,15 @@ export class QuestionListController {
         }
     ) {
         try {
-            if (!token) {
-                // 로그인 안함
-                // isScrap: false
-            }
+            const userId = token ? token.userId : null;
+
             const { categoryName } = body;
             query.category = categoryName;
-            const { allQuestionLists, meta } =
-                await this.questionListService.getAllQuestionLists(query);
+
+            const { allQuestionLists, meta } = await this.questionListService.getAllQuestionLists(
+                query,
+                userId
+            );
             return res.status(HttpStatus.OK).json({
                 success: true,
                 message: "All question lists received successfully.",

--- a/backend/src/question-list/question-list.controller.ts
+++ b/backend/src/question-list/question-list.controller.ts
@@ -165,12 +165,6 @@ export class QuestionListController {
         try {
             const userId = token ? token.userId : null;
 
-            if (!userId) {
-                // 로그인 안함
-                // isScrap: false
-                // 비공개 질문 접근 불가 처리
-            }
-
             const { questionListId } = body;
             const questionListContents: QuestionListContentsDto =
                 await this.questionListService.getQuestionListContents(questionListId, userId);

--- a/backend/src/question-list/question-list.service.ts
+++ b/backend/src/question-list/question-list.service.ts
@@ -28,7 +28,7 @@ export class QuestionListService {
         private readonly categoryRepository: CategoryRepository
     ) {}
 
-    async getAllQuestionLists(query: PaginateQueryDto) {
+    async getAllQuestionLists(query: PaginateQueryDto, userId: number) {
         const allQuestionLists: GetAllQuestionListDto[] = [];
 
         let categoryId = null;
@@ -53,12 +53,15 @@ export class QuestionListService {
                 where: { questionListId: id },
             });
 
+            const isScrap = await this.questionListRepository.isQuestionListScrapped(id, userId);
+
             const questionList: GetAllQuestionListDto = {
                 id,
                 title,
                 categoryNames,
                 usage,
                 questionCount,
+                isScrap,
             };
             allQuestionLists.push(questionList);
         }

--- a/backend/src/question-list/question-list.service.ts
+++ b/backend/src/question-list/question-list.service.ts
@@ -140,6 +140,8 @@ export class QuestionListService {
             ? await this.questionListRepository.isQuestionListScrapped(id, userId)
             : false;
 
+        const scrapCount = await this.questionListRepository.getScrapCount(id);
+
         const questionListContents: QuestionListContentsDto = {
             id,
             title,
@@ -148,6 +150,7 @@ export class QuestionListService {
             usage,
             username,
             isScrap,
+            scrapCount: parseInt(scrapCount.count),
         };
 
         return questionListContents;

--- a/backend/src/question-list/question-list.service.ts
+++ b/backend/src/question-list/question-list.service.ts
@@ -53,7 +53,9 @@ export class QuestionListService {
                 where: { questionListId: id },
             });
 
-            const isScrap = await this.questionListRepository.isQuestionListScrapped(id, userId);
+            const isScrap = userId
+                ? await this.questionListRepository.isQuestionListScrapped(id, userId)
+                : false;
 
             const questionList: GetAllQuestionListDto = {
                 id,
@@ -128,6 +130,7 @@ export class QuestionListService {
 
         const user = await this.userRepository.getUserByUserId(userId);
         const username = user.username;
+
         const questionListContents: QuestionListContentsDto = {
             id,
             title,

--- a/backend/src/question-list/repository/question-list.repository.ts
+++ b/backend/src/question-list/repository/question-list.repository.ts
@@ -68,6 +68,14 @@ export class QuestionListRepository extends Repository<QuestionList> {
             .then((result) => !!result);
     }
 
+    getScrapCount(questionListId: number) {
+        return this.createQueryBuilder("question_list")
+            .innerJoin("question_list.scrappedByUsers", "user")
+            .where("question_list.id = :questionListId", { questionListId })
+            .select("COUNT(user.id)", "count")
+            .getRawOne();
+    }
+
     async paginate(paginateDto: PaginateDto) {
         const { queryBuilder, skip, take, field, direction } = paginateDto;
         return await queryBuilder

--- a/backend/src/question-list/repository/question-list.repository.ts
+++ b/backend/src/question-list/repository/question-list.repository.ts
@@ -58,6 +58,16 @@ export class QuestionListRepository extends Repository<QuestionList> {
             .execute();
     }
 
+    isQuestionListScrapped(questionListId: number, userId: number) {
+        return this.createQueryBuilder("question_list")
+            .innerJoin("question_list.scrappedByUsers", "user")
+            .where("question_list.id = :questionListId", { questionListId })
+            .andWhere("user.id = :userId", { userId })
+            .select("1")
+            .getRawOne()
+            .then((result) => !!result);
+    }
+
     async paginate(paginateDto: PaginateDto) {
         const { queryBuilder, skip, take, field, direction } = paginateDto;
         return await queryBuilder


### PR DESCRIPTION
> [!Note]
> - 작성자: 송수민
> - 작성 날짜: 2024.12.04

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- 모든 API 응답에 적절한 상태 코드 반환
  - 로그인이 필요한 API에 401 상태 코드 반환
  - internal server error의 경우 500 상태 코드 반환
- 로그인 유무에 따라 적절한 응답 반환 
  - `isScrap`: boolean
    - 전체 질문지 조회
    - 카테고리별 질문지 조회
    - 질문지 상세 페이지 
  - `scrapCount`: boolean
    - 질문지 상세 페이지
  - 로그인하지 않은 유저는 모두 `false` 반환
- 질문지 작성자 관련 에러 fix

## 📝 작업 상세 내역
### 모든 API 응답에 적절한 상태 코드 반환
- 기존에는 응답의 성공 유무와 관계없이 200이나 201 상태 코드를 반환했었습니다.
- 상태 코드를 정확하게 반환해달라는 정우님의 요청으로 모든 API 요청이 적절한 상태 코드를 반환할 수 있도록 수정했습니다.
```ts
@Get("my")
@UseGuards(AuthGuard("jwt"))
@UsePipes(new ValidationPipe({ transform: true }))
async getMyQuestionLists(
    @Res() res,
    @Query() query: PaginateQueryDto,
    @JwtPayload() token: IJwtPayload
) {
    try {
        const userId = token ? token.userId : null;

        if (!userId)
            return res.status(HttpStatus.UNAUTHORIZED).json({ // 401 반환
                success: false,
                message: "Login required.",
            });

        const { myQuestionLists, meta } = await this.questionListService.getMyQuestionLists(
            userId,
            query
        );
        return res.status(HttpStatus.OK).json({ // 200 반환
            success: true,
            message: "My question lists received successfully.",
            data: {
                myQuestionLists,
                meta,
            },
        });
    } catch (error) {
        return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({ // 500 반환
            success: false,
            message: "Failed to get my question lists.",
            error: error.message,
        });
    }
}
```

### 로그인 유무에 따라 적절한 응답 반환
- 찬우님께서 인증 가드를 수정해주신 덕분에 로그인 유무에 따라 적절한 응답을 반환할 수 있게 되었습니다.
- 그와 관련된 `isScrap`, `scrapCount` 데이터를 반환할 수 있도록 구현했습니다.
- 아래의 서비스 로직에서 userId가 null인지의 여부(로그인 여부)에 따라 데이터를 true, false로 반환해주고 있습니다.
```ts
async getQuestionListContents(questionListId: number, userId: number) {
    const questionList = await this.questionListRepository.findOne({
        where: { id: questionListId },
    });

    const { id, title, usage, isPublic } = questionList;
    const authorId = questionList.userId;

    if (!isPublic) {
        if (!userId || questionList.userId !== userId) {
            throw new Error("This is a private question list.");
        }
    }

    const contents = await this.questionRepository.getContentsByQuestionListId(questionListId);

    const categoryNames =
        await this.categoryRepository.findCategoryNamesByQuestionListId(questionListId);

    const author = await this.userRepository.getUserByUserId(authorId);
    const username = author.username;

    const isScrap = userId
        ? await this.questionListRepository.isQuestionListScrapped(id, userId)
        : false;

    const scrapCount = await this.questionListRepository.getScrapCount(id);

    const questionListContents: QuestionListContentsDto = {
        id,
        title,
        contents,
        categoryNames,
        usage,
        username,
        isScrap,
        scrapCount: parseInt(scrapCount.count),
    };

    return questionListContents;
}
```

### 질문지 작성자 관련 에러 fix
- 질문지 상세 페이지에서 작성자를 의미하는 `username`에 나의 `username`을 반환하는 에러가 있었습니다.
- 이를 질문지 작성자의 `username`을 반환하도록 수정했습니다.

## 📌 테스트 및 검증 결과
- 로그인한 사용자가 받은 질문지 상세 페이지 응답
![image](https://github.com/user-attachments/assets/17a57558-fdda-4f39-87d0-4d8931e539fd)

## 💬 다음 작업 또는 논의 사항
- 남은 문서화