### PR TITLE
[Fix] 빌드에러 수정, vendor 파일로 리액트 라이브러리 별도의 청크 파일 분리

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -32,11 +32,10 @@ export default defineConfig({
   },
   build: {
     rollupOptions: {
-      external: ["react", "react-dom"],
       output: {
-        globals: {
-          react: "React",
-          "react-dom": "ReactDOM",
+        manualChunks: {
+          "vendor-react": ["react", "react-dom", "react-router-dom"],
+          "vendor-utils": ["lodash", "axios"],
         },
       },
     },


### PR DESCRIPTION
빌드에러 수정, vendor 파일로 리액트 라이브러리 별도의 청크 파일 분리

라이브러리용 빌드 라이브러리 분리 설정을 써서 배포가 안됐던 것 같습니다. vendor 파일로 분리해서 더 최적화하고 오류도 수정했습니다.