### PR TITLE
[Refactor] 세션 생성시 질문지 선택하는 부분에서 내가 만든, 스크랩한 질문지 조회 가능하도록 구현 및 리팩토링

### DIFF
--- a/frontend/src/api/question-list/getQuestionContent.ts
+++ b/frontend/src/api/question-list/getQuestionContent.ts
@@ -1,7 +1,7 @@
-import axios from "axios";
+import { api } from "@/api/config/axios.ts";
 
 const getQuestionContent = async (questionListId: number) => {
-  const response = await axios.post("/api/question-list/contents", {
+  const response = await api.post("/api/question-list/contents", {
     questionListId,
   });
 

--- a/frontend/src/components/sessions/create/SessionForm/CategorySection.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/CategorySection.tsx
@@ -1,17 +1,7 @@
 import SelectTitle from "@/components/common/Text/SelectTitle";
 import useSessionFormStore from "@/pages/CreateSessionPage/stores/useSessionFormStore";
 import CategorySelect from "@/components/common/Select/CategorySelect";
-
-const options = [
-  {
-    value: "프론트엔드",
-    label: "프론트엔드",
-  },
-  {
-    value: "백엔드",
-    label: "백엔드",
-  },
-];
+import { options } from "@/constants/CategoryData.ts";
 
 const CategorySection = () => {
   const { category, setCategory } = useSessionFormStore();

--- a/frontend/src/components/sessions/create/SessionForm/ListSelectModal/QuestionList/QuestionItem.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/ListSelectModal/QuestionList/QuestionItem.tsx
@@ -1,9 +1,7 @@
 import { GrDown, GrUp } from "react-icons/gr";
 import { ImCheckmark } from "react-icons/im";
 import useSessionFormStore from "@/pages/CreateSessionPage/stores/useSessionFormStore";
-import { useState } from "react";
 import LoadingIndicator from "@components/common/LoadingIndicator.tsx";
-import { api } from "@/api/config/axios.ts";
 import { FaUsers } from "react-icons/fa6";
 import { useGetQuestionContent } from "@hooks/api/useGetQuestionContent.ts";
 import ErrorBlock from "@components/common/Error/ErrorBlock.tsx";
@@ -112,6 +110,10 @@ const QuestionItem = ({ item }: { item: QuestionList }) => {
           })}
         </div>
       ) : null}
+      <ErrorBlock
+        error={error}
+        message={"질문 목록을 불러오는데 실패했습니다."}
+      />
     </>
   );
 };

--- a/frontend/src/components/sessions/create/SessionForm/ListSelectModal/QuestionList/QuestionItem.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/ListSelectModal/QuestionList/QuestionItem.tsx
@@ -76,8 +76,6 @@ const QuestionItem = ({ item }: { item: QuestionList }) => {
     }
   };
 
-  console.log(item);
-
   return (
     <>
       <div className="flex flex-row items-center w-full h-20 border-t-custom-s px-8 py-4">

--- a/frontend/src/components/sessions/create/SessionForm/ListSelectModal/QuestionList/QuestionItem.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/ListSelectModal/QuestionList/QuestionItem.tsx
@@ -48,6 +48,20 @@ const QuestionItem = ({ item }: { item: QuestionList }) => {
     }
   };
 
+  const renderDropdownIcon = () => {
+    return isListOpen ? (
+      <GrUp className="w-5 h-5 text-gray-600 " />
+    ) : (
+      <GrDown className="w-5 h-5 text-gray-600" />
+    );
+  };
+
+  // TODO: 북마크한 질문지 데이터에 카테고리 데이터, 사용 횟수 데이터 백엔드에게 요청
+
+  const selectedStyle = isSelected
+    ? "bg-green-200 text-green-50"
+    : "bg-gray-300 text-gray-50";
+
   return (
     <>
       <div className="flex flex-row items-center w-full h-20 border-t-custom-s px-8 py-4">
@@ -57,11 +71,7 @@ const QuestionItem = ({ item }: { item: QuestionList }) => {
             openHandler(item.id);
           }}
         >
-          {isListOpen ? (
-            <GrUp className="w-5 h-5 text-gray-600 " />
-          ) : (
-            <GrDown className="w-5 h-5 text-gray-600" />
-          )}
+          {renderDropdownIcon()}
         </button>
         <div
           className={"flex flex-grow justify-between cursor-pointer"}
@@ -86,17 +96,14 @@ const QuestionItem = ({ item }: { item: QuestionList }) => {
           </div>
           <button
             className={`flex items-center ml-auto w-10 h-10 rounded-custom-m
-            ${
-              isSelected
-                ? "bg-green-200 text-green-50"
-                : "bg-gray-300 text-gray-50"
-            }`}
+            ${selectedStyle}`}
           >
             <ImCheckmark className="m-auto w-5 h-5" />
           </button>
         </div>
       </div>
-      {isListOpen ? (
+
+      {isListOpen && (
         <div className="bg-gray-50 px-20 py-5 transition-all">
           <div className={"h-fit"}>
             <LoadingIndicator loadingState={questionLoading} />
@@ -109,7 +116,8 @@ const QuestionItem = ({ item }: { item: QuestionList }) => {
             );
           })}
         </div>
-      ) : null}
+      )}
+
       <ErrorBlock
         error={error}
         message={"질문 목록을 불러오는데 실패했습니다."}

--- a/frontend/src/components/sessions/create/SessionForm/ListSelectModal/QuestionList/QuestionItem.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/ListSelectModal/QuestionList/QuestionItem.tsx
@@ -5,16 +5,8 @@ import { useState } from "react";
 import LoadingIndicator from "@components/common/LoadingIndicator.tsx";
 import { api } from "@/api/config/axios.ts";
 import { FaUsers } from "react-icons/fa6";
-
-interface Question {
-  id: number;
-  content: string;
-  index: number;
-  questionListId: number;
-}
-interface QuestionsMap {
-  [key: number]: Question[];
-}
+import { useGetQuestionContent } from "@hooks/api/useGetQuestionContent.ts";
+import ErrorBlock from "@components/common/Error/ErrorBlock.tsx";
 
 interface QuestionList {
   id: number;
@@ -34,12 +26,15 @@ const QuestionItem = ({ item }: { item: QuestionList }) => {
     setSelectedOpenId,
   } = useSessionFormStore();
 
-  const [questions, setQuestions] = useState<Question[]>([]);
-  const [questionLoading, setQuestionLoading] = useState(true);
   const isSelected = questionId === item.id;
   const isListOpen = selectedOpenId === item.id;
+  const {
+    data,
+    isLoading: questionLoading,
+    error,
+  } = useGetQuestionContent(item.id);
 
-  const [questionMap, setQuestionMap] = useState<QuestionsMap>({});
+  const questions = data?.contents || [];
 
   const checkHandler = (id: number, title: string) => {
     setQuestionId(id);
@@ -51,28 +46,6 @@ const QuestionItem = ({ item }: { item: QuestionList }) => {
       setSelectedOpenId(-1);
     } else {
       setSelectedOpenId(id);
-    }
-
-    if (questionMap[id]) {
-      setQuestions(questionMap[id]);
-    } else {
-      getQuestionListDetail();
-    }
-  };
-
-  const getQuestionListDetail = async () => {
-    try {
-      setQuestionLoading(true);
-      const response = await api.post(`/api/question-list/contents`, {
-        questionListId: item.id,
-      });
-      const questionsData: Question[] =
-        response.data.data.questionListContents.contents;
-      setQuestionMap({ ...questionMap, [item.id]: questionsData });
-      setQuestions(questionsData);
-      setQuestionLoading(false);
-    } catch (e) {
-      console.error("질문지 리스트 디테일 불러오기 실패", e);
     }
   };
 

--- a/frontend/src/components/sessions/create/SessionForm/ListSelectModal/QuestionList/QuestionItem.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/ListSelectModal/QuestionList/QuestionItem.tsx
@@ -38,6 +38,7 @@ const QuestionItem = ({ item }: { item: QuestionList }) => {
 
   const checkHandler = (id: number, title: string) => {
     setQuestionId(id);
+    setSelectedOpenId(id);
     setQuestionTitle(title);
   };
 
@@ -64,34 +65,38 @@ const QuestionItem = ({ item }: { item: QuestionList }) => {
             <GrDown className="w-5 h-5 text-gray-600" />
           )}
         </button>
-        <div>
-          <div className="flex items-center leading-5 gap-3  mb-1">
-            <div
-              className={
-                "text-medium-s bg-green-100 bg-opacity-30 rounded-md px-2 text-white"
-              }
-            >
-              {item.categoryNames ? item.categoryNames[0]! : "미분류"}
+        <div
+          className={"flex flex-grow justify-between cursor-pointer"}
+          onClick={() => {
+            checkHandler(item.id, item.title);
+          }}
+        >
+          <div>
+            <div className="flex items-center leading-5 gap-3  mb-1">
+              <div
+                className={
+                  "text-medium-s bg-green-100 bg-opacity-30 rounded-md px-2 text-white"
+                }
+              >
+                {item.categoryNames ? item.categoryNames[0]! : "미분류"}
+              </div>
+              <span className="inline-flex items-center gap-1 leading-5 text-medium-s text-gray-600">
+                <FaUsers /> {item.usage}
+              </span>
             </div>
-            <span className="inline-flex items-center gap-1 leading-5 text-medium-s text-gray-600">
-              <FaUsers /> {item.usage}
-            </span>
+            <p className="text-semibold-r text-gray-black">{item.title}</p>
           </div>
-          <p className="text-semibold-r text-gray-black">{item.title}</p>
-        </div>
-        <button
-          className={`flex items-center ml-auto w-10 h-10 rounded-custom-m
+          <button
+            className={`flex items-center ml-auto w-10 h-10 rounded-custom-m
             ${
               isSelected
                 ? "bg-green-200 text-green-50"
                 : "bg-gray-300 text-gray-50"
             }`}
-          onClick={() => {
-            checkHandler(item.id, item.title);
-          }}
-        >
-          <ImCheckmark className="m-auto w-5 h-5" />
-        </button>
+          >
+            <ImCheckmark className="m-auto w-5 h-5" />
+          </button>
+        </div>
       </div>
       {isListOpen ? (
         <div className="bg-gray-50 px-20 py-5 transition-all">

--- a/frontend/src/components/sessions/create/SessionForm/ListSelectModal/QuestionList/index.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/ListSelectModal/QuestionList/index.tsx
@@ -1,5 +1,6 @@
 import QuestionItem from "./QuestionItem";
 import LoadingIndicator from "@components/common/LoadingIndicator.tsx";
+import NotFound from "@components/common/Animate/NotFound.tsx";
 
 interface QuestionList {
   id: number;
@@ -26,13 +27,26 @@ const QuestionList = ({ questionList, questionLoading }: QuestionItemProps) => {
   return (
     <div className="mb-4 h-80 overflow-y-auto">
       <LoadingIndicator loadingState={questionLoading} />
-      {questionList?.map((item, id) => {
-        return (
-          <div key={id}>
-            <QuestionItem item={item} />
-          </div>
-        );
-      })}
+      {questionList.length > 0 ? (
+        questionList.map((item, id) => {
+          return (
+            <div key={id}>
+              <QuestionItem item={item} />
+            </div>
+          );
+        })
+      ) : (
+        <div className="flex justify-center items-center h-80">
+          <NotFound
+            className={"flex justify-center h-50"}
+            message={"아직 질문지 리스트가 없어요!"}
+            redirect={{
+              path: "/questions/create",
+              buttonText: "질문지 만들러 가기",
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/sessions/create/SessionForm/ListSelectModal/index.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/ListSelectModal/index.tsx
@@ -77,6 +77,7 @@ const ListSelectModal = ({ modal: { dialogRef, closeModal } }: ModalProps) => {
     }
   };
 
+  // TODO: 카테고리 선택 시 해당 카테고리의 질문지 리스트를 불러오는 로직 추가
   return (
     <dialog
       ref={dialogRef}

--- a/frontend/src/components/sessions/create/SessionForm/ListSelectModal/index.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/ListSelectModal/index.tsx
@@ -23,14 +23,14 @@ interface ModalProps {
 const ListSelectModal = ({ modal: { dialogRef, closeModal } }: ModalProps) => {
   const { tab, setTab, setSelectedOpenId } = useSessionFormStore();
   const [page, setPage] = useState(1);
-
+  const MAX_ITEM_PER_PAGE = 4;
   const {
     data: myQuestionList,
     isLoading: myQuestionLoading,
     error: myQuestionError,
   } = useGetMyQuestionList({
     page: page,
-    limit: 4,
+    limit: MAX_ITEM_PER_PAGE,
   });
 
   const {
@@ -39,7 +39,7 @@ const ListSelectModal = ({ modal: { dialogRef, closeModal } }: ModalProps) => {
     error: scrapError,
   } = useGetScrapQuestionList({
     page: page,
-    limit: 4,
+    limit: MAX_ITEM_PER_PAGE,
   });
 
   const questionList =

--- a/frontend/src/components/sessions/create/SessionForm/ListSelectModal/index.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/ListSelectModal/index.tsx
@@ -8,6 +8,8 @@ import Pagination from "@components/common/Pagination";
 import { useGetMyQuestionList } from "@hooks/api/useGetMyQuestionList.ts";
 import ErrorBlock from "@components/common/Error/ErrorBlock.tsx";
 import { useGetScrapQuestionList } from "@hooks/api/useGetScrapQuestionList.ts";
+import CategorySelect from "@components/common/Select/CategorySelect.tsx";
+import { options } from "@/constants/CategoryData.ts";
 
 interface UseModalReturn {
   dialogRef: React.RefObject<HTMLDialogElement>;
@@ -23,6 +25,8 @@ interface ModalProps {
 const ListSelectModal = ({ modal: { dialogRef, closeModal } }: ModalProps) => {
   const { tab, setTab, setSelectedOpenId } = useSessionFormStore();
   const [page, setPage] = useState(1);
+  const [selectedCategory, setSelectedCategory] = useState("");
+
   const MAX_ITEM_PER_PAGE = 4;
   const {
     data: myQuestionList,
@@ -86,7 +90,12 @@ const ListSelectModal = ({ modal: { dialogRef, closeModal } }: ModalProps) => {
           <IoMdClose className="text-gray-black w-7 h-7" />
         </button>
       </div>
-      <div className="mx-8 mb-8">
+      <div className="h-11 flex gap-2 items-stretch justify-between mx-8 mb-8">
+        <CategorySelect
+          value={selectedCategory}
+          setValue={setSelectedCategory}
+          options={options}
+        />
         <SearchBar text="질문지를 검색해주세요" />
       </div>
       <QuestionList

--- a/frontend/src/components/sessions/create/SessionForm/ListSelectModal/index.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/ListSelectModal/index.tsx
@@ -22,15 +22,14 @@ interface ModalProps {
 
 const ListSelectModal = ({ modal: { dialogRef, closeModal } }: ModalProps) => {
   const { tab, setTab, setSelectedOpenId } = useSessionFormStore();
-  const [myListPage, setMyListPage] = useState(1);
-  const [savedListPage, setSavedListPage] = useState(1);
+  const [page, setPage] = useState(1);
 
   const {
     data: myQuestionList,
     isLoading: myQuestionLoading,
     error: myQuestionError,
   } = useGetMyQuestionList({
-    page: tab === "myList" ? myListPage : savedListPage,
+    page: page,
     limit: 4,
   });
 
@@ -39,7 +38,7 @@ const ListSelectModal = ({ modal: { dialogRef, closeModal } }: ModalProps) => {
     isLoading: scrapQuestionLoading,
     error: scrapError,
   } = useGetScrapQuestionList({
-    page: tab === "myList" ? myListPage : savedListPage,
+    page: page,
     limit: 4,
   });
 
@@ -54,17 +53,11 @@ const ListSelectModal = ({ modal: { dialogRef, closeModal } }: ModalProps) => {
       ? myQuestionList?.meta.totalPages || 1
       : scrapQuestionList?.meta.totalPages || 1;
 
-  console.log(questionList);
-
   const getCurrentPageProps = () => ({
-    currentPage: tab === "myList" ? myListPage : savedListPage,
+    currentPage: page,
     totalPage: totalPage,
     onPageChange: (page: number) => {
-      if (tab === "myList") {
-        setMyListPage(page);
-      } else {
-        setSavedListPage(page);
-      }
+      setPage(page);
     },
   });
 

--- a/frontend/src/components/sessions/create/SessionForm/TitleSection.tsx
+++ b/frontend/src/components/sessions/create/SessionForm/TitleSection.tsx
@@ -7,7 +7,7 @@ const TitleSection = () => {
 
   return (
     <div>
-      <SelectTitle title="스터디 세션" />
+      <SelectTitle title="스터디 채널 이름" />
       <TitleInput
         placeholder="예) 프론트엔드 면접 스터디"
         onChange={(e) => setSessionName(e.target.value)}

--- a/frontend/src/constants/CategoryData.ts
+++ b/frontend/src/constants/CategoryData.ts
@@ -5,11 +5,11 @@ export const options = [
   },
   {
     value: "프론트엔드",
-    label: "FE",
+    label: "프론트엔드",
   },
   {
     value: "백엔드",
-    label: "BE",
+    label: "백엔드",
   },
   {
     value: "운영체제",

--- a/frontend/src/pages/CreateSessionPage/CreateSessionPage.tsx
+++ b/frontend/src/pages/CreateSessionPage/CreateSessionPage.tsx
@@ -11,6 +11,10 @@ const CreateSessionPage = () => {
 
   useEffect(() => {
     resetForm();
+
+    return () => {
+      resetForm();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/frontend/src/pages/CreateSessionPage/stores/useSessionFormStore.ts
+++ b/frontend/src/pages/CreateSessionPage/stores/useSessionFormStore.ts
@@ -52,7 +52,7 @@ const useSessionFormStore = create<SessionFormState>((set, get) => ({
     return (
       state.category.trim() !== "" &&
       state.sessionName.trim() !== "" &&
-      state.sessionName.trim().length > 5 &&
+      state.sessionName.trim().length >= 5 &&
       state.questionId > 0 &&
       state.questionTitle.trim() !== ""
     );

--- a/frontend/src/pages/CreateSessionPage/view/SessionForm.tsx
+++ b/frontend/src/pages/CreateSessionPage/view/SessionForm.tsx
@@ -75,7 +75,7 @@ const SessionForm = () => {
       socket.off(SESSION_LISTEN_EVENT.CREATE, roomCreatedHandler);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [socket, navigate]);
+  }, [socket]);
 
   return (
     <div className="flex flex-col gap-7 p-8 bg-gray-white shadow-8 w-47.5 rounded-custom-l">


### PR DESCRIPTION
> [!NOTE]
> 세션 생성 페이지에서 내가 만든, 내가 스크랩한 질문지를 선택할 수 있게 구현했습니다. 몇몇 UX측면 리팩토링 진행했습니다.


## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- 세션 생성시 내가 만든 질문지, 스크랩한 질문지 조회 기능 구현
- 모달 내 조회에 페이지네이션 도입
- 기존: 체크 박스를 클릭해야만 선택, 변경: 질문지 아이템 자체를 클릭해도 선택되도록 수정
- 질문지 아이템 선택하면 자동으로 열리도록 수정
- 몇몇 코드 중복제거
- 세션 이름이 5글자가 되면 빨간글씨는 없어지지만 세션 생성이 되지 않던 문제 해결
- 질문지 선택 모달에서 질문지가 없을 경우 NotFound 컴포넌트를 렌더링

## 📝 작업 상세 내역
### 세션 생성시 내가 만든 질문지, 스크랩한 질문지 조회 기능 및 페이지네이션
![image](https://github.com/user-attachments/assets/694f4a65-7af3-450a-b6d6-e18d6cec61eb)

### NotFound
지금 보니 버튼이 없어도 될 것 같기도..
![image](https://github.com/user-attachments/assets/c33ba2ba-7fc4-41b7-afaf-928a99ca3c62)

## 🐥 리뷰 받고 싶은 포인트(선택)
- 리액트 쿼리 부분